### PR TITLE
VIM-3207: Incorrect logic when checking for free disk space

### DIFF
--- a/VimeoUpload/Extensions/NSFileManager+Extensions.swift
+++ b/VimeoUpload/Extensions/NSFileManager+Extensions.swift
@@ -33,7 +33,7 @@ extension NSFileManager
         let documentsPath = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0]
         let dictionary = try self.attributesOfFileSystemForPath(documentsPath)
 
-        return dictionary[NSFileSystemSize] as? NSNumber
+        return dictionary[NSFileSystemFreeSize] as? NSNumber
     }
     
     func deleteFileAtURL(url: NSURL)

--- a/VimeoUpload/Operations/Async/MeOperation.swift
+++ b/VimeoUpload/Operations/Async/MeOperation.swift
@@ -104,8 +104,6 @@ class MeOperation: ConcurrentOperation
     {
         super.cancel()
         
-        print("MeOperation cancelled")
-
         self.task?.cancel()
         self.task = nil
     }

--- a/VimeoUpload/Operations/Sync/DailyQuotaOperation.swift
+++ b/VimeoUpload/Operations/Sync/DailyQuotaOperation.swift
@@ -59,11 +59,4 @@ class DailyQuotaOperation: NSOperation
             self.error = NSError(domain: DailyQuotaOperation.ErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "User object did not contain uploadQuota.quota information"])
         }
     }
-    
-    override func cancel()
-    {
-        super.cancel()
-    
-        print("DailyQuotaOperation cancelled")
-    }
 }

--- a/VimeoUpload/Operations/Sync/DiskSpaceOperation.swift
+++ b/VimeoUpload/Operations/Sync/DiskSpaceOperation.swift
@@ -57,19 +57,12 @@ class DiskSpaceOperation: NSOperation
             }
             else
             {
-                self.error = NSError(domain: DiskSpaceOperation.ErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "File system information did not contain NSFileSystemSize key:value pair"])
+                self.error = NSError(domain: DiskSpaceOperation.ErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "File system information did not contain NSFileSystemFreeSize key:value pair"])
             }
         }
         catch
         {
             self.error = NSError(domain: DiskSpaceOperation.ErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Unable to calculate available disk space"])
         }
-    }
-    
-    override func cancel()
-    {
-        super.cancel()
-        
-        print("DiskSpaceOperation cancelled")
     }
 }

--- a/VimeoUpload/Operations/Sync/WeeklyQuotaOperation.swift
+++ b/VimeoUpload/Operations/Sync/WeeklyQuotaOperation.swift
@@ -60,11 +60,4 @@ class WeeklyQuotaOperation: NSOperation
             self.error = NSError(domain: WeeklyQuotaOperation.ErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "User object did not contain uploadQuota.space information"])
         }
     }
-    
-    override func cancel()
-    {
-        super.cancel()
-        
-        print("WeeklyQuotaOperation cancelled")
-    }
 }


### PR DESCRIPTION
https://vimean.atlassian.net/browse/VIM-3207

This PR resolves a bug surfaced by @dinasolovey. My check for free disk space was being done incorrectly, resulting in disk space errors not being flagged appropriately. 
