### PR TITLE
VIM-3208: Handling quota updates that occur while the app is backgrounded (edge case)

### DIFF
--- a/VimeoUpload/Controllers/VideoDeletionManager.swift
+++ b/VimeoUpload/Controllers/VideoDeletionManager.swift
@@ -176,9 +176,9 @@ class VideoDeletionManager: NSObject
     
     private func addObservers()
     {
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationDidBecomeActive:", name: UIApplicationDidBecomeActiveNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationWillEnterForeground:", name: UIApplicationWillEnterForegroundNotification, object: nil)
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationWillResignActive:", name: UIApplicationWillResignActiveNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationDidEnterBackground:", name: UIApplicationDidEnterBackgroundNotification, object: nil)
     }
     
     private func removeObservers()
@@ -186,12 +186,12 @@ class VideoDeletionManager: NSObject
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
     
-    func applicationDidBecomeActive(notification: NSNotification)
+    func applicationWillEnterForeground(notification: NSNotification)
     {
         self.startDeletions()
     }
 
-    func applicationWillResignActive(notification: NSNotification)
+    func applicationDidEnterBackground(notification: NSNotification)
     {
         self.operationQueue.cancelAllOperations()
     }

--- a/VimeoUpload/Networking/VimeoSessionManager.swift
+++ b/VimeoUpload/Networking/VimeoSessionManager.swift
@@ -31,9 +31,7 @@ typealias AuthTokenBlock = () -> String
 class VimeoSessionManager: AFHTTPSessionManager
 {    
     // MARK: Initialization
-    
-    // MARK:
-    
+        
     static func defaultSessionManager(authToken authToken: String) -> VimeoSessionManager
     {
         let sessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration()


### PR DESCRIPTION
Added logic to refresh the me object upon return from background, in the event that the user updates their quota while the app is backgrounded.

https://vimean.atlassian.net/browse/VIM-3208
