### PR TITLE
VIM-3308: Abstracting upload a bit to accommodate new download system

### DIFF
--- a/VimeoUpload/Descriptors/Descriptor.swift
+++ b/VimeoUpload/Descriptors/Descriptor.swift
@@ -47,7 +47,12 @@ enum State: String
 
 class Descriptor: NSObject, DescriptorProtocol
 {
-    // MARK: 
+    private static let StateCoderKey = "state"
+    private static let IdentifierCoderKey = "identifier"
+    private static let ErrorCoderKey = "error"
+    private static let CurrentTaskIdentifierCoderKey = "currentTaskIdentifier"
+
+    // MARK:
     
     dynamic private(set) var stateObservable: String = State.Ready.rawValue
     var state = State.Ready
@@ -55,6 +60,11 @@ class Descriptor: NSObject, DescriptorProtocol
         didSet
         {
             self.stateObservable = state.rawValue
+            
+            if self.state == .Finished
+            {
+                self.currentTaskIdentifier = nil
+            }
         }
     }
     
@@ -62,6 +72,16 @@ class Descriptor: NSObject, DescriptorProtocol
     
     var identifier: String?
     var error: NSError?
+    {
+        didSet
+        {
+            if error != nil
+            {
+                self.state = .Finished
+            }
+        }
+    }
+
     var currentTaskIdentifier: Int?
 
     // MARK: - Initialization
@@ -180,20 +200,20 @@ class Descriptor: NSObject, DescriptorProtocol
     
     required init(coder aDecoder: NSCoder)
     {
-        self.state = State(rawValue: aDecoder.decodeObjectForKey("state") as! String)! // If force unwrap fails we have a big problem
-        self.identifier = aDecoder.decodeObjectForKey("identifier") as? String
-        self.error = aDecoder.decodeObjectForKey("error") as? NSError
-        self.currentTaskIdentifier = aDecoder.decodeIntegerForKey("currentTaskIdentifier")
+        self.state = State(rawValue: aDecoder.decodeObjectForKey(self.dynamicType.StateCoderKey) as! String)!
+        self.identifier = aDecoder.decodeObjectForKey(self.dynamicType.IdentifierCoderKey) as? String
+        self.error = aDecoder.decodeObjectForKey(self.dynamicType.ErrorCoderKey) as? NSError
+        self.currentTaskIdentifier = aDecoder.decodeIntegerForKey(self.dynamicType.CurrentTaskIdentifierCoderKey)
     }
     
     func encodeWithCoder(aCoder: NSCoder)
     {
-        aCoder.encodeObject(self.state.rawValue, forKey: "state")
-        aCoder.encodeObject(self.identifier, forKey: "identifier")
-        aCoder.encodeObject(self.error, forKey: "error")
+        aCoder.encodeObject(self.state.rawValue, forKey: self.dynamicType.StateCoderKey)
+        aCoder.encodeObject(self.identifier, forKey: self.dynamicType.IdentifierCoderKey)
+        aCoder.encodeObject(self.error, forKey: self.dynamicType.ErrorCoderKey)
         if let currentTaskIdentifier = self.currentTaskIdentifier
         {
-            aCoder.encodeInteger(currentTaskIdentifier, forKey: "currentTaskIdentifier")
+            aCoder.encodeInteger(currentTaskIdentifier, forKey: self.dynamicType.CurrentTaskIdentifierCoderKey)
         }
     }
 }

--- a/VimeoUpload/Descriptors/ProgressDescriptor.swift
+++ b/VimeoUpload/Descriptors/ProgressDescriptor.swift
@@ -1,0 +1,61 @@
+//
+//  ProgressDescriptor.swift
+//  Smokescreen
+//
+//  Created by Alfred Hanssen on 2/2/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import UIKit
+
+class ProgressDescriptor: Descriptor
+{
+    // MARK:
+    
+    // We observe progress here via progressObservable because the descriptor is the only object that knows about the progress object's lifecycle
+    // If we allow views to observe the progress they wont know exactly when to remove and add observers when the descriptor is
+    // suspended and resumed [AH] 12/25/2015
+    
+    private static let ProgressKeyPath = "fractionCompleted"
+    private var progressKVOContext = UInt8()
+    dynamic private(set) var progressObservable: Double = 0
+    var progress: NSProgress?
+    {
+        willSet
+        {
+            self.progress?.removeObserver(self, forKeyPath: self.dynamicType.ProgressKeyPath, context: &self.progressKVOContext)
+        }
+        
+        didSet
+        {
+            self.progress?.addObserver(self, forKeyPath: self.dynamicType.ProgressKeyPath, options: NSKeyValueObservingOptions.New, context: &self.progressKVOContext)
+        }
+    }
+
+    // MARK: - Initialization
+    
+    deinit
+    {
+        self.progress = nil
+    }
+
+    // MARK: KVO
+    
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>)
+    {
+        if let keyPath = keyPath
+        {
+            switch (keyPath, context)
+            {
+            case(self.dynamicType.ProgressKeyPath, &self.progressKVOContext):
+                self.progressObservable = change?[NSKeyValueChangeNewKey]?.doubleValue ?? 0
+            default:
+                super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
+            }
+        }
+        else
+        {
+            super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
+        }
+    }
+}

--- a/VimeoUpload/Extensions/AFURLSessionManager+Extensions.swift
+++ b/VimeoUpload/Extensions/AFURLSessionManager+Extensions.swift
@@ -44,9 +44,4 @@ extension AFURLSessionManager
     {
         return self.tasks.filter{ $0.taskIdentifier == identifier }.first as? NSURLSessionTask
     }
-
-    func uploadTaskForIdentifier(identifier: Int) -> NSURLSessionUploadTask?
-    {
-        return self.uploadTasks.filter{ $0.taskIdentifier == identifier }.first as? NSURLSessionUploadTask
-    }
 }

--- a/VimeoUpload/Extensions/AFURLSessionManager+Upload.swift
+++ b/VimeoUpload/Extensions/AFURLSessionManager+Upload.swift
@@ -1,0 +1,17 @@
+//
+//  AFURLSessionManager+Upload.swift
+//  Smokescreen
+//
+//  Created by Alfred Hanssen on 2/2/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import Foundation
+
+extension AFURLSessionManager
+{
+    func uploadTaskForIdentifier(identifier: Int) -> NSURLSessionUploadTask?
+    {
+        return self.uploadTasks.filter{ $0.taskIdentifier == identifier }.first as? NSURLSessionUploadTask
+    }
+}

--- a/VimeoUpload/Networking/Private/VimeoSessionManager+Upload2.swift
+++ b/VimeoUpload/Networking/Private/VimeoSessionManager+Upload2.swift
@@ -54,7 +54,7 @@ extension VimeoSessionManager
             })
         })
         
-        task.taskDescription = TaskDescription.CreateVideo.rawValue
+        task.taskDescription = UploadTaskDescription.CreateVideo.rawValue
         
         return task
     }

--- a/VimeoUpload/Networking/Upload/VimeoSessionManager+Upload.swift
+++ b/VimeoUpload/Networking/Upload/VimeoSessionManager+Upload.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 
-enum TaskDescription: String
+enum UploadTaskDescription: String
 {
     case Me = "Me"
     case MyVideos = "MyVideos"
@@ -66,7 +66,7 @@ extension VimeoSessionManager
             })
         })
         
-        task.taskDescription = TaskDescription.Me.rawValue
+        task.taskDescription = UploadTaskDescription.Me.rawValue
         
         return task
     }
@@ -97,7 +97,7 @@ extension VimeoSessionManager
             })
         })
         
-        task.taskDescription = TaskDescription.MyVideos.rawValue
+        task.taskDescription = UploadTaskDescription.MyVideos.rawValue
         
         return task
     }
@@ -108,7 +108,7 @@ extension VimeoSessionManager
 
         let task = self.downloadTaskWithRequest(request, progress: nil, destination: nil, completionHandler: nil)
         
-        task.taskDescription = TaskDescription.CreateVideo.rawValue
+        task.taskDescription = UploadTaskDescription.CreateVideo.rawValue
         
         return task
     }
@@ -135,7 +135,7 @@ extension VimeoSessionManager
             }
         })
 
-        task.taskDescription = TaskDescription.UploadVideo.rawValue
+        task.taskDescription = UploadTaskDescription.UploadVideo.rawValue
         
         return task
     }
@@ -147,7 +147,7 @@ extension VimeoSessionManager
         
         let task = self.downloadTaskWithRequest(request, progress: nil, destination: nil, completionHandler: nil)
         
-        task.taskDescription = TaskDescription.ActivateVideo.rawValue
+        task.taskDescription = UploadTaskDescription.ActivateVideo.rawValue
         
         return task
     }    
@@ -159,7 +159,7 @@ extension VimeoSessionManager
         
         let task = self.downloadTaskWithRequest(request, progress: nil, destination: nil, completionHandler: nil)
         
-        task.taskDescription = TaskDescription.VideoSettings.rawValue
+        task.taskDescription = UploadTaskDescription.VideoSettings.rawValue
         
         return task
     }
@@ -190,7 +190,7 @@ extension VimeoSessionManager
             })
         })
         
-        task.taskDescription = TaskDescription.VideoSettings.rawValue
+        task.taskDescription = UploadTaskDescription.VideoSettings.rawValue
         
         return task
     }
@@ -217,7 +217,7 @@ extension VimeoSessionManager
             }
         })
         
-        task.taskDescription = TaskDescription.DeleteVideo.rawValue
+        task.taskDescription = UploadTaskDescription.DeleteVideo.rawValue
         
         return task
     }
@@ -244,7 +244,7 @@ extension VimeoSessionManager
             }
         })
         
-        task.taskDescription = TaskDescription.Video.rawValue
+        task.taskDescription = UploadTaskDescription.Video.rawValue
         
         return task
     }


### PR DESCRIPTION
#### Ticket

[VIM-3308](https://vimean.atlassian.net/browse/VIM-3308)
#### Ticket Summary

The new download system will leverage the `Descriptor` system. Some abstractions were necessary to reduce code duplication and make some classes that are not upload-specific truly not upload-specific. 
#### Implementation Summary
1. Moved coder keys into constants
2. Created an intermediate class `ProgressDescriptor` to consolidate some duplicate code
3. Fixed a potential weakness in one of the methods on `VimeoResponseSerializer`
4. Changed some error domains to no longer be upload-specific
#### How to Test

Test upload, although these changes are super minimal. Any breakages will be exposed during my download testing and @dinasolovey's upload testing. 
