### PR TITLE
VIM-3559: Deadlock when entering airplane mode with multiple uploads or downloads in progress (~5)

### DIFF
--- a/VimeoUpload/Upload/Controllers/DescriptorManagerDebugger.swift
+++ b/VimeoUpload/Upload/Controllers/DescriptorManagerDebugger.swift
@@ -121,13 +121,13 @@ class DescriptorManagerDebugger: DescriptorManagerDelegate
     {
         print(message)
         
-        dispatch_async(dispatch_get_main_queue()) { () -> Void in
-            
-            let localNotification = UILocalNotification()
-            localNotification.timeZone = NSTimeZone.defaultTimeZone()
-            localNotification.alertBody = message
-            
-            UIApplication.sharedApplication().presentLocalNotificationNow(localNotification)
-        }
+//        dispatch_async(dispatch_get_main_queue()) { () -> Void in
+//            
+//            let localNotification = UILocalNotification()
+//            localNotification.timeZone = NSTimeZone.defaultTimeZone()
+//            localNotification.alertBody = message
+//            
+//            UIApplication.sharedApplication().presentLocalNotificationNow(localNotification)
+//        }
     }
 }


### PR DESCRIPTION
#### Ticket

**Required for Vimeans only**
[VIM-3559](https://vimean.atlassian.net/browse/VIM-3559)
#### Ticket Summary

Initiate 5 uploads. Enter airplane mode. App freezes. 
#### Implementation Summary

This one was a doozy. A deadlock was occurring when suspending the queue with multiple active tasks. Due to using dispatch_sync instead of async. I was using sync so because I was under the impression that the backgroundEventsCompletionHandler had to be called immediately when the application delegate receives it. But this is not so (and doesn't really make sense if you think about it). If this doesn't need to be called synchronously (i.e. at that moment) then none of the other blocks invoked in response to task handling need to be called synchronously. This means they can all be dispatched async and will be processed in the proper order, maintaining thread safety and background session lifecycle integrity, but with no deadlock.
#### How to Test

Do the steps in the "ticket summary" above. 
