### PR TITLE
VIM-3775: Fixed download cancellation issue

### DIFF
--- a/VimeoUpload/Upload/Descriptors/Upload2/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptors/Upload2/UploadDescriptor.swift
@@ -82,6 +82,8 @@ class UploadDescriptor: ProgressDescriptor, VideoDescriptor
         {
             guard let uploadLinkSecure = self.uploadTicket.uploadLinkSecure else
             {
+                // TODO: delete file here? Same in download?
+                
                 throw NSError(domain: UploadErrorDomain.Upload.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to initiate upload but the uploadUri is nil."])
             }
             
@@ -128,8 +130,10 @@ class UploadDescriptor: ProgressDescriptor, VideoDescriptor
             // This error is thrown if you initiate an upload and then kill the app from the multitasking view in mid-upload
             // Upon reopening the app, the descriptor is loaded but no longer has a task 
          
+            NSFileManager.defaultManager().deleteFileAtURL(self.url)
+
             let error = NSError(domain: UploadErrorDomain.Upload.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Loaded descriptor from cache that does not have a task associated with it."])
-            self.error = error
+            self.error = error // TODO: Whenever we set error delete local file? Same for download?
             self.state = .Finished
             
             throw error

--- a/VimeoUpload/VideoDescriptorFailureTracker.swift
+++ b/VimeoUpload/VideoDescriptorFailureTracker.swift
@@ -122,7 +122,9 @@ import Foundation
     
     func descriptorDidFail(notification: NSNotification)
     {
-        if let descriptor = notification.object as? Descriptor, let key = (descriptor as? VideoDescriptor)?.videoUri where descriptor.error != nil
+        if let descriptor = notification.object as? Descriptor,
+            let key = (descriptor as? VideoDescriptor)?.videoUri
+            where descriptor.error != nil
         {
             dispatch_async(dispatch_get_main_queue()) { () -> Void in
                 self.failedDescriptors[key] = descriptor


### PR DESCRIPTION
#### Ticket

[VIM-3775](https://vimean.atlassian.net/browse/VIM-3775)
#### Ticket Summary

Downloads cancelled from multitasking cancel were not flagged as cancellations.
#### Implementation Summary

I forgot to re-add the error when "loadFromCache" fails.
#### How to Test

Follow steps in ticket.
