### PR TITLE
VIM-3812: Made enum objc compatible

### DIFF
--- a/VimeoUpload/Upload/Descriptors/VideoDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptors/VideoDescriptor.swift
@@ -26,13 +26,13 @@
 
 import Foundation
 
-enum VideoDescriptorType
+@objc enum VideoDescriptorType: Int
 {
     case Upload
     case Download
 }
 
-protocol VideoDescriptor
+@objc protocol VideoDescriptor
 {
     var type: VideoDescriptorType { get }
     


### PR DESCRIPTION
#### Ticket

**Required for Vimeans only**
[VIM-3812](https://vimean.atlassian.net/browse/VIM-3812)
#### Ticket Summary

This is related to the above ticket. Ran into some Swift <> Objc interoperability issues.
#### Implementation Summary

Made Swift enum Objc compatible. 
#### How to Test

NA
