### PR TITLE
Trims whitespace from title in VideoSettings

### DIFF
--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -32,7 +32,7 @@ class VideoSettings: NSObject
     {
         didSet
         {
-            self.title = self.title?.trim()
+            self.title = title?.trim()
         }
     }
     
@@ -40,7 +40,7 @@ class VideoSettings: NSObject
     {
         didSet
         {
-            self.desc = self.desc?.trim()
+            self.desc = desc?.trim()
         }
     }
     

--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -36,7 +36,8 @@ class VideoSettings: NSObject
 
     init(title: String?, description: String?, privacy: String?, users: [String]?, password: String?)
     {
-        self.title = title
+        // Remove trailing whitespace [CL]
+        self.title = title?.trim()
         self.desc = description
         self.privacy = privacy
         self.users = users

--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -29,19 +29,37 @@ import Foundation
 class VideoSettings: NSObject
 {
     var title: String?
+    {
+        didSet
+        {
+            self.title = self.title?.trim()
+        }
+    }
+    
     var desc: String?
+    {
+        didSet
+        {
+            self.desc = self.desc?.trim()
+        }
+    }
+    
     var privacy: String?
     var users: [String]? // List of uris of users who can view this video
     var password: String?
 
     init(title: String?, description: String?, privacy: String?, users: [String]?, password: String?)
     {
-        // Remove trailing whitespace [CL]
-        self.title = title?.trim()
-        self.desc = description
         self.privacy = privacy
         self.users = users
         self.password = password
+        
+        super.init()
+        
+        defer {
+            self.title = title
+            self.desc = description
+        }
     }
     
     // MARK: Public API

--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -32,7 +32,7 @@ class VideoSettings: NSObject
     {
         didSet
         {
-            self.title = title?.trim()
+            self.title = self.title?.trim()
         }
     }
     
@@ -40,26 +40,21 @@ class VideoSettings: NSObject
     {
         didSet
         {
-            self.desc = desc?.trim()
+            self.desc = self.desc?.trim()
         }
     }
     
     var privacy: String?
     var users: [String]? // List of uris of users who can view this video
     var password: String?
-
+    
     init(title: String?, description: String?, privacy: String?, users: [String]?, password: String?)
     {
+        self.title = title?.trim()
+        self.desc = description?.trim()
         self.privacy = privacy
         self.users = users
         self.password = password
-        
-        super.init()
-        
-        defer {
-            self.title = title
-            self.desc = description
-        }
     }
     
     // MARK: Public API

--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -47,7 +47,7 @@ class VideoSettings: NSObject
     var privacy: String?
     var users: [String]? // List of uris of users who can view this video
     var password: String?
-    
+
     init(title: String?, description: String?, privacy: String?, users: [String]?, password: String?)
     {
         self.title = title?.trim()


### PR DESCRIPTION

<b>Ticket</b>
https://vimean.atlassian.net/browse/VIM-3848

<b>Ticket Summary</b>
"Something strange occurred" alert when you upload video with just spaces in title

<b>Implementation Summary</b>

Trim whitespace from title before starting upload
How To Test
1. open the app 
2. upload your video 
3. tap on a video and set your title with only spaces 
4. tap [upload]
5. Title is now "Untitled"

