### PR TITLE
VIM-3723: Multitask cancellations are now always flagged as errors

### DIFF
--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -225,16 +225,11 @@ class DescriptorManager: NSObject
 
                     return
                 }
-
-                // This case should not be necessary, isNetworkTaskCancellationError should always be covered by the .Suspended case above.
-                // This needs testing to deem if necessary. [AH] 2/22/2016
-                let isNetworkCancellationError = (task.error?.isNetworkTaskCancellationError() == true || error?.isNetworkTaskCancellationError() == true)
                 
                 // These types of errors can occur when connection drops and before suspend() is called,
                 // Or when connection drop is slow -> timeouts etc. [AH] 2/22/2016
                 let isConnectionError = (task.error?.isConnectionError() == true || error?.isConnectionError() == true)
-                
-                if isNetworkCancellationError || isConnectionError
+                if isConnectionError
                 {
                     do
                     {

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -157,13 +157,6 @@ class UploadDescriptor: ProgressDescriptor, VideoDescriptor
             return
         }
 
-        if task.error?.isNetworkTaskCancellationError() == true || error?.isNetworkTaskCancellationError() == true
-        {
-            assertionFailure("taskDidComplete was called for a descriptor that failed dur to connection error.")
-            
-            return
-        }
-
         if self.error == nil
         {
             if let taskError = task.error // task.error is reserved for client-side errors, so check it first


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-3723](https://vimean.atlassian.net/browse/VIM-3723)

#### Ticket Summary
Initiating an upload or download from certain iOS8 devices (e.g. iOS 8.2) and immediately killing the app. Upon re-launching the app the download or upload would automatically restart instead of being flagged as a failure. 

#### Implementation Summary
Removed the check against `isNetworkCancellationError`. This seemed iffy for one, and it was included at the 11th hour before launch of Vimeo iOS v6.0. It also doesn't appear to be necessary. We should just let the error fall through and be captured by the normal error catch at the bottom of `taskDidComplete:`.

#### How to Test
See ticket.
