### PR TITLE
VIM 3848: Removes some redundancy from VideoSettings

### DIFF
--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -55,12 +55,8 @@ class VideoSettings: NSObject
         self.privacy = privacy
         self.users = users
         self.password = password
-        
-        // Wrap in closure so didSet gets called [CL] 3/25/16
-        ({
-            self.title = title
-            self.desc = description
-        })()
+        self.title = self.trim(title)
+        self.desc = self.trim(description)
     }
     
     // MARK: Public API

--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -56,6 +56,7 @@ class VideoSettings: NSObject
         self.users = users
         self.password = password
         
+        // Wrap in closure so didSet gets called [CL] 3/25/16
         ({
             self.title = title
             self.desc = description

--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -32,7 +32,7 @@ class VideoSettings: NSObject
     {
         didSet
         {
-            self.title = trim(self.title)
+            self.title = self.trim(self.title)
         }
     }
     
@@ -40,7 +40,7 @@ class VideoSettings: NSObject
     {
         didSet
         {
-            self.desc = trim(self.desc)
+            self.desc = self.trim(self.desc)
         }
     }
     
@@ -55,8 +55,11 @@ class VideoSettings: NSObject
         self.privacy = privacy
         self.users = users
         self.password = password
-        self.title = self.trim(title)
-        self.desc = self.trim(description)
+        
+        ({
+            self.title = title
+            self.desc = description
+        })()
     }
     
     // MARK: Public API


### PR DESCRIPTION
<b>Ticket</b>
https://vimean.atlassian.net/browse/VIM-3848

<b>Ticket Summary</b>
"Something strange occurred" alert when you upload video with just spaces in title

<b>Implementation Summary</b>

Trim whitespace from title before starting upload
How To Test
1. open the app 
2. upload your video 
3. tap on a video and set your title with only spaces 
4. tap [upload]
5. Title is now "Untitled"
