### PR TITLE
VIM-3844: Bogus filesize calculations

### DIFF
--- a/VimeoUpload/Upload/Operations/Async/ExportOperation.swift
+++ b/VimeoUpload/Upload/Operations/Async/ExportOperation.swift
@@ -52,7 +52,7 @@ class ExportOperation: ConcurrentOperation
     
     convenience init(asset: AVAsset)
     {
-        let exportSession = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetHighestQuality)!
+        let exportSession = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetPassthrough)!
         
         self.init(exportSession: exportSession)
     }
@@ -115,6 +115,7 @@ class ExportOperation: ConcurrentOperation
         }
 
         // AVAssetExportSession does not do an internal check to see if there's ample disk space available to perform the export [AH] 12/06/2015
+        // However this check will not work with presetName "passthrough" since that preset reports estimatedOutputFileLength of zero always.
         
         let availableDiskSpace = try? NSFileManager.defaultManager().availableDiskSpace() // Double optional
         if let diskSpace = availableDiskSpace, let space = diskSpace where space.longLongValue < self.exportSession.estimatedOutputFileLength

--- a/VimeoUpload/Upload/Operations/Async/iOS8/PHAssetExportSessionOperation.swift
+++ b/VimeoUpload/Upload/Operations/Async/iOS8/PHAssetExportSessionOperation.swift
@@ -46,7 +46,7 @@ class PHAssetExportSessionOperation: ConcurrentOperation
         self.cleanup()
     }
     
-    init(phAsset: PHAsset, exportPreset: String = AVAssetExportPresetHighestQuality)
+    init(phAsset: PHAsset, exportPreset: String = AVAssetExportPresetPassthrough)
     {
         self.phAsset = phAsset
         self.exportPreset = exportPreset


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-3844](https://vimean.atlassian.net/browse/VIM-3844)

#### Ticket Summary
Large multi-GB files are failing in the export stage due to filesize overage. But filesize reported in the camera roll view is less than the available space reported in device settings. What gives?

#### Implementation Summary
Export preset "highest quality" enlarges files. For example a file whose original asset is roughly 2.2GB becomes roughly 3.5GB when exported at "highest" preset. This was never being communicated to users. It also means more upload quota-related failures. So we're switching to export preset "passthrough" as the default. The exported filesize for a "passthrough" file is roughly the same as the filesize we display in the camera roll view. So the calculations are in sync, correct info is communicated to the user. 

#### How to Test
Perform tests described in ticket linked to above.