### PR TITLE
VIM-4015: Make VimeoUpload Consumable as a Cocoapod

### DIFF
--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS.xcodeproj/project.pbxproj
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS.xcodeproj/project.pbxproj
@@ -1016,6 +1016,7 @@
 				INFOPLIST_FILE = "VimeoUpload-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alfiehanssen.VimeoUpload-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "${SRCROOT}/VimeoUpload-iOS/Bridge.h";
@@ -1030,6 +1031,7 @@
 				INFOPLIST_FILE = "VimeoUpload-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alfiehanssen.VimeoUpload-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "${SRCROOT}/VimeoUpload-iOS/Bridge.h";

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/Bridge.h
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/Bridge.h
@@ -24,5 +24,5 @@
 //  THE SOFTWARE.
 //
 
-@import AFNetworking;
-@import VIMNetworking;
+//@import AFNetworking;
+//@import VIMNetworking;

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/Bridge.h
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/Bridge.h
@@ -24,5 +24,5 @@
 //  THE SOFTWARE.
 //
 
-//@import AFNetworking;
-//@import VIMNetworking;
+@import AFNetworking;
+@import VIMNetworking;

--- a/VimeoUpload.podspec
+++ b/VimeoUpload.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "VimeoUpload"
-  s.version      = "0.9.0"
+  s.version      = "0.9.1"
   s.summary      = "The Vimeo iOS/OSX Upload SDK."
   s.description  = <<-DESC
                             An iOS/OSX library for uploading videos to Vimeo. The library supports the existing server-side upload flow. It also supports a new private server-side upload flow that will soon be made public. VimeoUpload's core can be extended to support any NSURLSession(background)Task workflow.'
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 #  s.osx.deployment_target = '10.9'
 
   s.source       = { :git => "https://github.com/vimeo/VimeoUpload.git", :tag => s.version.to_s }
-  s.source_files  = "VimeoUpload/**/*.{swift}", "VimeoUpload+UIKit/**/*.{swift}"
+  s.source_files  = "VimeoUpload/**/*.{swift}"
 
   s.requires_arc = true
 
@@ -31,7 +31,6 @@ Pod::Spec.new do |s|
 #  s.osx.frameworks = "Foundation", "AVFoundation", "CoreServices", "Cocoa"
 #  s.osx.exclude_files = "VimeoUpload/Operations/PHAssetOperation.swift"
 
-  s.dependency 'AFNetworking', '2.6.3'
-  s.dependency 'VIMNetworking/Model', '6.0.0'
+  s.dependency 'VIMNetworking', '6.0.4'
 
 end

--- a/VimeoUpload.podspec
+++ b/VimeoUpload.podspec
@@ -32,5 +32,6 @@ Pod::Spec.new do |s|
 #  s.osx.exclude_files = "VimeoUpload/Operations/PHAssetOperation.swift"
 
   s.dependency 'VIMNetworking', '6.0.4'
+  s.compiler_flags = '-D COCOAPOD_VERSION'
 
 end

--- a/VimeoUpload.podspec
+++ b/VimeoUpload.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "VimeoUpload"
-  s.version      = "0.9.2"
+  s.version      = "0.9.1"
   s.summary      = "The Vimeo iOS/OSX Upload SDK."
   s.description  = <<-DESC
                             An iOS/OSX library for uploading videos to Vimeo. The library supports the existing server-side upload flow. It also supports a new private server-side upload flow that will soon be made public. VimeoUpload's core can be extended to support any NSURLSession(background)Task workflow.'

--- a/VimeoUpload.podspec
+++ b/VimeoUpload.podspec
@@ -32,6 +32,5 @@ Pod::Spec.new do |s|
 #  s.osx.exclude_files = "VimeoUpload/Operations/PHAssetOperation.swift"
 
   s.dependency 'VIMNetworking', '6.0.4'
-  s.compiler_flags = '-D COCOAPOD_VERSION'
 
 end

--- a/VimeoUpload/Descriptor System/ConnectivityManager.swift
+++ b/VimeoUpload/Descriptor System/ConnectivityManager.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 
 protocol ConnectivityManagerDelegate: class
 {

--- a/VimeoUpload/Descriptor System/Descriptor.swift
+++ b/VimeoUpload/Descriptor System/Descriptor.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 
 enum DescriptorState: String
 {

--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 
 enum DescriptorManagerNotification: String
 {

--- a/VimeoUpload/Extensions/AFURLSessionManager+Extensions.swift
+++ b/VimeoUpload/Extensions/AFURLSessionManager+Extensions.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 
 extension AFURLSessionManager
 {

--- a/VimeoUpload/Networking/VimeoRequestSerializer.swift
+++ b/VimeoUpload/Networking/VimeoRequestSerializer.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 
 class VimeoRequestSerializer: AFJSONRequestSerializer
 {

--- a/VimeoUpload/Networking/VimeoResponseSerializer.swift
+++ b/VimeoUpload/Networking/VimeoResponseSerializer.swift
@@ -26,6 +26,10 @@
 
 import Foundation
 
+#if COCOAPOD_VERSION
+    import AFNetworking
+#endif
+
 class VimeoResponseSerializer: AFJSONResponseSerializer
 {
     private static let ErrorDomain = "VimeoResponseSerializerErrorDomain"

--- a/VimeoUpload/Networking/VimeoResponseSerializer.swift
+++ b/VimeoUpload/Networking/VimeoResponseSerializer.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 
 class VimeoResponseSerializer: AFJSONResponseSerializer
 {

--- a/VimeoUpload/Networking/VimeoResponseSerializer.swift
+++ b/VimeoUpload/Networking/VimeoResponseSerializer.swift
@@ -26,10 +26,6 @@
 
 import Foundation
 
-#if COCOAPOD_VERSION
-    import AFNetworking
-#endif
-
 class VimeoResponseSerializer: AFJSONResponseSerializer
 {
     private static let ErrorDomain = "VimeoResponseSerializerErrorDomain"

--- a/VimeoUpload/Networking/VimeoSessionManager.swift
+++ b/VimeoUpload/Networking/VimeoSessionManager.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 
 typealias AuthTokenBlock = () -> String?
 

--- a/VimeoUpload/UIKit/ALAssetHelper.swift
+++ b/VimeoUpload/UIKit/ALAssetHelper.swift
@@ -27,6 +27,7 @@
 import Foundation
 import AssetsLibrary
 import AVFoundation
+import UIKit
 
 @objc class ALAssetHelper: NSObject, CameraRollAssetHelper
 {

--- a/VimeoUpload/Upload/Descriptor System/Old Upload/OldUploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/Old Upload/OldUploadDescriptor.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 
 class OldUploadDescriptor: ProgressDescriptor, VideoDescriptor
 {

--- a/VimeoUpload/Upload/Extensions/AFURLSessionManager+Upload.swift
+++ b/VimeoUpload/Upload/Extensions/AFURLSessionManager+Upload.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 
 extension AFURLSessionManager
 {


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-4015](https://vimean.atlassian.net/browse/VIM-4015)

#### Ticket Summary
Make this library consumable as a pod.

#### Implementation Summary
Total failure :imp:. The combination of iOS7 and Cocoapods and Objc and Swift creates a stew of frustration. This lays some groundwork for when we deprecate support for iOS7 in the Vimeo iOS app. But it does not make this library consumable as a pod. 

#### How to Test
Confirm this library and its sample projects still build.

