### PR TITLE
CAM-287: expose the ReachableDescriptorManager delegate

### DIFF
--- a/VimeoUpload/VimeoUploader.swift
+++ b/VimeoUpload/VimeoUploader.swift
@@ -45,20 +45,21 @@ public class VimeoUploader<T: VideoDescriptor>
 
     // MARK: - Initialization
 
-    public convenience init(backgroundSessionIdentifier: String, accessToken: String)
+    public convenience init(backgroundSessionIdentifier: String, descriptorManagerDelegate: DescriptorManagerDelegate? = nil, accessToken: String)
     {
-        self.init(backgroundSessionIdentifier: backgroundSessionIdentifier, accessTokenProvider: { () -> String? in
+        self.init(backgroundSessionIdentifier: backgroundSessionIdentifier, descriptorManagerDelegate: descriptorManagerDelegate, accessTokenProvider: { () -> String? in
             return accessToken
         })
     }
-
-    public init(backgroundSessionIdentifier: String, accessTokenProvider: VimeoRequestSerializer.AccessTokenProvider)
+    
+    public init(backgroundSessionIdentifier: String, descriptorManagerDelegate: DescriptorManagerDelegate? = nil, accessTokenProvider: VimeoRequestSerializer.AccessTokenProvider)
     {
         self.foregroundSessionManager = VimeoSessionManager.defaultSessionManager(accessTokenProvider: accessTokenProvider)
         
         self.deletionManager = VideoDeletionManager(sessionManager: self.foregroundSessionManager)
         
-        self.descriptorManager = ReachableDescriptorManager(name: self.dynamicType.Name, backgroundSessionIdentifier: backgroundSessionIdentifier, accessTokenProvider: accessTokenProvider)
+        self.descriptorManager = ReachableDescriptorManager(name: self.dynamicType.Name, backgroundSessionIdentifier: backgroundSessionIdentifier, descriptorManagerDelegate: descriptorManagerDelegate,
+                                                            accessTokenProvider: accessTokenProvider)
     }
     
     // MARK: Public API - Starting


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[CAM-287](https://vimean.atlassian.net/browse/CAM-287)

#### Ticket Summary
In order to track when an upload completes in Cameo we want the ability to set the ReachableDescriptorManager object's delegate in the VimeoUploader class.

#### Implementation Summary
The ReachableDescriptorManager class already allows it's delegate to be set in the initializer, I just added this parameter to the initializer for the VimeoUploader class so it can be passed in.

#### How to Test
N/A
