### PR TITLE
CAM-208: changing scope of some properties to public

### DIFF
--- a/VimeoUpload/UIKit/Model/VIMALAsset.swift
+++ b/VimeoUpload/UIKit/Model/VIMALAsset.swift
@@ -27,16 +27,16 @@
 import AssetsLibrary
 import AVFoundation
 
-@objc class VIMALAsset: NSObject, CameraRollAsset
+@objc public class VIMALAsset: NSObject, CameraRollAsset
 {
-    let alAsset: ALAsset
+    public let alAsset: ALAsset
 
-    init(alAsset: ALAsset)
+    public init(alAsset: ALAsset)
     {
         self.alAsset = alAsset
     }
 
-    var identifier: String
+    public var identifier: String
     {
         get
         {
@@ -44,7 +44,7 @@ import AVFoundation
         }
     }
     
-    var inCloud: Bool = false
-    var avAsset: AVAsset?
-    var error: NSError?
+    public var inCloud: Bool = false
+    public var avAsset: AVAsset?
+    public var error: NSError?
 }

--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -28,7 +28,7 @@ import Foundation
 
 public class VideoSettings: NSObject
 {
-    var title: String?
+    public var title: String?
     {
         didSet
         {
@@ -36,7 +36,7 @@ public class VideoSettings: NSObject
         }
     }
     
-    var desc: String?
+    public var desc: String?
     {
         didSet
         {
@@ -44,9 +44,9 @@ public class VideoSettings: NSObject
         }
     }
     
-    var privacy: String?
-    var users: [String]? // List of uris of users who can view this video
-    var password: String?
+    public var privacy: String?
+    public var users: [String]? // List of uris of users who can view this video
+    public var password: String?
 
     public init(title: String?, description: String?, privacy: String?, users: [String]?, password: String?)
     {


### PR DESCRIPTION
#### Ticket
[CAM-208](https://vimean.atlassian.net/browse/CAM-208)

#### Ticket Summary
Add upload analytics to Cameo that mirror the ones implemented in Vimeo iOS.

#### Implementation Summary
In order to implement the same analytics in Cameo that Vimeo iOS has, I need to change the scope of certain properties and init functions so they can be accessed in Cameo.  This isn't an issue for Vimeo iOS because the upload library is not linked in as a module.

#### How to Test
N/A