### PR TITLE
CAM-279: Upload Enhancements

### DIFF
--- a/VimeoUpload/Upload/Descriptor System/VideoDescriptorFailureTracker.swift
+++ b/VimeoUpload/Upload/Descriptor System/VideoDescriptorFailureTracker.swift
@@ -33,7 +33,7 @@ import Foundation
     // MARK: 
     
     private let archiver: KeyedArchiver
-    private var failedDescriptors: [VideoUri: Descriptor] = [:]
+    private var failedDescriptors: [String: Descriptor] = [:]
 
     // MARK: - Initialization
     
@@ -70,9 +70,9 @@ import Foundation
         return KeyedArchiver(basePath: documentsURL.path!)
     }
     
-    private func load() -> [VideoUri: Descriptor]
+    private func load() -> [String: Descriptor]
     {
-        return self.archiver.loadObjectForKey(self.dynamicType.ArchiveKey) as? [VideoUri: Descriptor] ?? [:]
+        return self.archiver.loadObjectForKey(self.dynamicType.ArchiveKey) as? [String: Descriptor] ?? [:]
     }
     
     private func save()
@@ -88,7 +88,7 @@ import Foundation
         self.save()
     }
     
-    public func removeFailedDescriptorForKey(key: VideoUri) -> Descriptor?
+    public func removeFailedDescriptorForKey(key: String) -> Descriptor?
     {
         guard let descriptor = self.failedDescriptors.removeValueForKey(key) else
         {
@@ -100,7 +100,7 @@ import Foundation
         return descriptor
     }
     
-    public func failedDescriptorForKey(key: VideoUri) -> Descriptor?
+    public func failedDescriptorForKey(key: String) -> Descriptor?
     {
         return self.failedDescriptors[key]
     }
@@ -123,7 +123,7 @@ import Foundation
     func descriptorDidFail(notification: NSNotification)
     {
         if let descriptor = notification.object as? Descriptor,
-            let key = (descriptor as? VideoDescriptor)?.videoUri
+            let key = descriptor.identifier
             where descriptor.error != nil
         {
             dispatch_async(dispatch_get_main_queue()) { () -> Void in
@@ -135,7 +135,8 @@ import Foundation
     
     func descriptorDidCancel(notification: NSNotification)
     {
-        if let descriptor = notification.object as? Descriptor, let key = (descriptor as? VideoDescriptor)?.videoUri
+        if let descriptor = notification.object as? Descriptor,
+            let key = descriptor.identifier
         {
             dispatch_async(dispatch_get_main_queue()) { () -> Void in
                 self.removeFailedDescriptorForKey(key)


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[CAM-279](https://vimean.atlassian.net/browse/CAM-279)

#### Ticket Summary
Ensure that videos can only be shared once they enter the .Available state. 

This ticket also included representing server-side upload state in UI. But this is premature. This needs to be thought through more thoroughly from product and design.

#### Implementation Summary
A variety of things: 

- Stripped CMProject status enum down into .Open and .Closed only. 
- Propagated this change throughout the codebase, fixed a few bugs that it triggered. 
- Changed name of `clipURL` to `videoLink`. 
- Using project identifier as the `descriptor.identifier` instead of the `videoURI`. 
- Setting `videoLink`, `videoURI`, and `videoResourceKey` on upload success only, instead of upfront.
- Changed how uploads are cancelled: centralized the logic, ensured that the video is deleted from Vimeo on upload cancellation. 
- Now tracking `videoStatus` on the CMProject. Using this to determine shareability.

#### How to Test
1. Upload a video
2. Attempt to share during upload and immediately after. Neither should work. You should see the same ol' alert saying, "wait until transcoding finishes". 
3. Confirm that upload cancellation is working as expected. 

