### PR TITLE
CAM-308: Added a new upload descriptor for Cameo

### DIFF
--- a/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
+++ b/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C53EC241D219C8500B7AA6D /* CAMUploadDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC1F1D219C8500B7AA6D /* CAMUploadDescriptor.swift */; };
+		3C53EC251D219C8500B7AA6D /* CAMUploadReqest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC201D219C8500B7AA6D /* CAMUploadReqest.swift */; };
+		3C53EC261D219C8500B7AA6D /* VimeoRequestSerializer+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC211D219C8500B7AA6D /* VimeoRequestSerializer+Thumbnail.swift */; };
+		3C53EC271D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC221D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift */; };
+		3C53EC281D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */; };
 		8D9A15BCC5ABADC2D001B20C /* Pods_VimeoUpload.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D4E8D665288660F1F668B91 /* Pods_VimeoUpload.framework */; };
 		AF40D4E51CCE9CB600753ABA /* VimeoUpload.h in Headers */ = {isa = PBXBuildFile; fileRef = AF40D4E41CCE9CB600753ABA /* VimeoUpload.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AF40D4EC1CCE9CB600753ABA /* VimeoUpload.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF40D4E11CCE9CB600753ABA /* VimeoUpload.framework */; };
@@ -87,6 +92,11 @@
 
 /* Begin PBXFileReference section */
 		3025B25CFC98F15CAC8EB4E9 /* Pods-VimeoUpload.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoUpload.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-VimeoUpload/Pods-VimeoUpload.debug.xcconfig"; sourceTree = "<group>"; };
+		3C53EC1F1D219C8500B7AA6D /* CAMUploadDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CAMUploadDescriptor.swift; path = Cameo/CAMUploadDescriptor.swift; sourceTree = "<group>"; };
+		3C53EC201D219C8500B7AA6D /* CAMUploadReqest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CAMUploadReqest.swift; path = Cameo/CAMUploadReqest.swift; sourceTree = "<group>"; };
+		3C53EC211D219C8500B7AA6D /* VimeoRequestSerializer+Thumbnail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoRequestSerializer+Thumbnail.swift"; path = "Cameo/VimeoRequestSerializer+Thumbnail.swift"; sourceTree = "<group>"; };
+		3C53EC221D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoResponseSerializer+Thumbnail.swift"; path = "Cameo/VimeoResponseSerializer+Thumbnail.swift"; sourceTree = "<group>"; };
+		3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoSessionManager+ThumbnailUpload.swift"; path = "Cameo/VimeoSessionManager+ThumbnailUpload.swift"; sourceTree = "<group>"; };
 		4D4E8D665288660F1F668B91 /* Pods_VimeoUpload.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoUpload.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF40D4E11CCE9CB600753ABA /* VimeoUpload.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VimeoUpload.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF40D4E41CCE9CB600753ABA /* VimeoUpload.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VimeoUpload.h; sourceTree = "<group>"; };
@@ -179,6 +189,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3C53EC1E1D219C6800B7AA6D /* Cameo (Private) */ = {
+			isa = PBXGroup;
+			children = (
+				3C53EC1F1D219C8500B7AA6D /* CAMUploadDescriptor.swift */,
+				3C53EC201D219C8500B7AA6D /* CAMUploadReqest.swift */,
+				3C53EC211D219C8500B7AA6D /* VimeoRequestSerializer+Thumbnail.swift */,
+				3C53EC221D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift */,
+				3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */,
+			);
+			name = "Cameo (Private)";
+			sourceTree = "<group>";
+		};
 		5DE6B4A5D1C90E1783FCACAB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -334,6 +356,7 @@
 		AF40D5191CCE9DEB00753ABA /* Descriptor System */ = {
 			isa = PBXGroup;
 			children = (
+				3C53EC1E1D219C6800B7AA6D /* Cameo (Private) */,
 				AF40D51A1CCE9DEB00753ABA /* DescriptorManagerTracker.swift */,
 				AF40D51B1CCE9DEB00753ABA /* New Upload (Private) */,
 				AF40D51D1CCE9DEB00753ABA /* Old Upload */,
@@ -640,6 +663,7 @@
 				AF40D5631CCE9DEB00753ABA /* VIMPHAsset.swift in Sources */,
 				AF40D5621CCE9DEB00753ABA /* VIMALAsset.swift in Sources */,
 				AF40D5691CCE9DEB00753ABA /* OldUploadDescriptor.swift in Sources */,
+				3C53EC271D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift in Sources */,
 				AF40D5641CCE9DEB00753ABA /* PHAssetHelper.swift in Sources */,
 				AF40D55F1CCE9DEB00753ABA /* CameraRollAssetHelper.swift in Sources */,
 				AF40D5741CCE9DEB00753ABA /* VimeoRequestSerializer+Upload.swift in Sources */,
@@ -662,6 +686,7 @@
 				AF40D5651CCE9DEB00753ABA /* VideoDeletionManager.swift in Sources */,
 				AF40D57A1CCE9DEB00753ABA /* DeleteVideoOperation.swift in Sources */,
 				AF40D5851CCE9DEB00753ABA /* ExportQuotaCreateOperation.swift in Sources */,
+				3C53EC251D219C8500B7AA6D /* CAMUploadReqest.swift in Sources */,
 				AF40D5571CCE9DEB00753ABA /* KeyedArchiver.swift in Sources */,
 				AF40D5661CCE9DEB00753ABA /* VideoRefreshManager.swift in Sources */,
 				AF40D55D1CCE9DEB00753ABA /* ALAssetHelper.swift in Sources */,
@@ -672,6 +697,7 @@
 				AF40D5871CCE9DEB00753ABA /* ALAssetRetryUploadOperation.swift in Sources */,
 				AF40D5511CCE9DEB00753ABA /* ArchiverProtocol.swift in Sources */,
 				AF40D5561CCE9DEB00753ABA /* DescriptorManagerDelegate.swift in Sources */,
+				3C53EC261D219C8500B7AA6D /* VimeoRequestSerializer+Thumbnail.swift in Sources */,
 				AF40D56D1CCE9DEB00753ABA /* AFURLSessionManager+Upload.swift in Sources */,
 				AF40D5551CCE9DEB00753ABA /* DescriptorManagerArchiver.swift in Sources */,
 				AF40D58E1CCE9DEB00753ABA /* VimeoUploader.swift in Sources */,
@@ -688,12 +714,14 @@
 				AF40D5801CCE9DEB00753ABA /* PHAssetExportSessionOperation.swift in Sources */,
 				AF40D5771CCE9DEB00753ABA /* VimeoResponseSerializer+OldUpload.swift in Sources */,
 				AF40D55E1CCE9DEB00753ABA /* CameraRollAssetCell.swift in Sources */,
+				3C53EC241D219C8500B7AA6D /* CAMUploadDescriptor.swift in Sources */,
 				AF40D5581CCE9DEB00753ABA /* ProgressDescriptor.swift in Sources */,
 				AF40D55A1CCE9DEB00753ABA /* AFURLSessionManager+Extensions.swift in Sources */,
 				AF40D58D1CCE9DEB00753ABA /* WeeklyQuotaOperation.swift in Sources */,
 				AF40D5791CCE9DEB00753ABA /* ConcurrentOperation.swift in Sources */,
 				AF40D5781CCE9DEB00753ABA /* VimeoSessionManager+OldUpload.swift in Sources */,
 				AF40D5721CCE9DEB00753ABA /* BlockTypes.swift in Sources */,
+				3C53EC281D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift in Sources */,
 				AF40D56A1CCE9DEB00753ABA /* OldUploadRequest.swift in Sources */,
 				AF40D57B1CCE9DEB00753ABA /* ExportOperation.swift in Sources */,
 				AF40D55B1CCE9DEB00753ABA /* NSError+Extensions.swift in Sources */,

--- a/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import AFNetworking
 import VimeoNetworking
 
 //TODO: Once this class is moved into VimeoUpload, we can remove this import.  [MW] 6/27/16
@@ -16,10 +17,12 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
 {
     let videoUrl: NSURL
     let videoSettings: VideoSettings?
-    let thumbnailUrl: NSURL
+    let thumbnailFileUrl: NSURL?
     
     private(set) var uploadTicket: VIMUploadTicket?
     private(set) var video: VIMVideo?
+    private(set) var thumbnailTicket: VIMThumbnailUploadTicket?
+    private(set) var thumbnail: VIMPicture?
     
     private (set) var currentRequest = CAMUploadRequest.CreateVideo
     {
@@ -37,9 +40,6 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
     }
     
     public var videoUri: VideoUri?
-    {
-        return self.uploadTicket?.video?.uri
-    }
     
     public var progressDescriptor: ProgressDescriptor
     {
@@ -53,11 +53,11 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
         fatalError("default init() should not be used, use init(videoUrl:videoSettings:thumbnailUrl:) instead")
     }
     
-    public init(videoUrl: NSURL, videoSettings: VideoSettings? = nil, thumbnailUrl: NSURL)
+    public init(videoUrl: NSURL, videoSettings: VideoSettings? = nil, thumbnailFileUrl: NSURL?)
     {
         self.videoUrl = videoUrl
         self.videoSettings = videoSettings
-        self.thumbnailUrl = thumbnailUrl
+        self.thumbnailFileUrl = thumbnailFileUrl
         
         super.init()
     }
@@ -82,6 +82,164 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
         }
     }
     
+    //TODO: need to figure out how this method changes to include the thumbnail upload [MW] 6/27/16
+    override func resume(sessionManager sessionManager: AFURLSessionManager)
+    {
+        super.resume(sessionManager: sessionManager)
+        
+        if let identifier = self.currentTaskIdentifier,
+            task = sessionManager.uploadTaskForIdentifier(identifier),
+            progress = sessionManager.uploadProgressForTask(task)
+        {
+            self.progress = progress
+        }
+    }
+    
+    override func cancel(sessionManager sessionManager: AFURLSessionManager)
+    {
+        super.cancel(sessionManager: sessionManager)
+        
+        NSFileManager.defaultManager().deleteFileAtURL(self.videoUrl)
+        
+        if let thumbnailFileUrl = self.thumbnailFileUrl {
+            NSFileManager.defaultManager().deleteFileAtURL(thumbnailFileUrl)
+        }
+    }
+    
+    //TODO: need to figure out how this method changes to include the thumbnail upload [MW] 6/27/16
+    override func didLoadFromCache(sessionManager sessionManager: AFURLSessionManager) throws
+    {
+        guard let identifier = self.currentTaskIdentifier,
+            task = sessionManager.uploadTaskForIdentifier(identifier),
+            progress = sessionManager.uploadProgressForTask(task) else
+        {
+            NSFileManager.defaultManager().deleteFileAtURL(self.videoUrl)
+            
+            if let thumbnailFileUrl = self.thumbnailFileUrl {
+                NSFileManager.defaultManager().deleteFileAtURL(thumbnailFileUrl)
+            }
+            
+            let error = NSError(domain: UploadErrorDomain.Upload.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Loaded descriptor from cache that does not have a task associated with it."])
+            self.error = error // TODO: Whenever we set error delete local file? Same for download?
+            self.currentTaskIdentifier = nil
+            self.state = .Finished
+            
+            throw error
+        }
+        
+        self.progress = progress
+    }
+    
+    override func taskDidFinishDownloading(sessionManager sessionManager: AFURLSessionManager, task: NSURLSessionDownloadTask, url: NSURL) -> NSURL?
+    {
+        let sessionManager = sessionManager as! VimeoSessionManager
+        let responseSerializer = sessionManager.responseSerializer as! VimeoResponseSerializer
+        
+        do
+        {
+            switch self.currentRequest
+            {
+            case .CreateVideo:
+                self.uploadTicket = try responseSerializer.processCreateVideoResponse(task.response, url: url, error: error)
+                
+            case .UploadVideo:
+                break
+                
+            case .ActivateVideo:
+                self.videoUri = try responseSerializer.processActivateVideoResponse(task.response, url: url, error: error)
+                
+            case .VideoSettings:
+                self.video = try responseSerializer.processVideoSettingsResponse(task.response, url: url, error: error)
+                
+            case .CreateThumbnail:
+                self.thumbnailTicket = try responseSerializer.processCreateThumbnailResponse(task.response, url: url, error: error)
+                
+            case .UploadThumbnail:
+                break
+                
+            case .ActivateThumbnail:
+                self.thumbnail = try responseSerializer.processActivateThumbnailResponse(task.response, url: url, error: error)
+            }
+        }
+        catch let error as NSError
+        {
+            self.error = error
+            self.currentTaskIdentifier = nil
+            self.state = .Finished
+        }
+        
+        return nil
+    }
+    
+    //TODO: need to figure out how this method changes to include the thumbnail upload [MW] 6/27/16
+    override func taskDidComplete(sessionManager sessionManager: AFURLSessionManager, task: NSURLSessionTask, error: NSError?)
+    {
+        if self.currentRequest == .UploadVideo
+        {
+            NSFileManager.defaultManager().deleteFileAtURL(self.videoUrl)
+        }
+        else if self.currentRequest == .UploadThumbnail
+        {
+            if let thumbnailFileUrl = self.thumbnailFileUrl {
+                NSFileManager.defaultManager().deleteFileAtURL(thumbnailFileUrl)
+            }
+        }
+        
+        if self.error == nil
+        {
+            if let taskError = task.error // task.error is reserved for client-side errors, so check it first
+            {
+                let domain = self.errorDomainForRequest(self.currentRequest)
+                self.error = taskError.errorByAddingDomain(domain)
+            }
+            else if let error = error
+            {
+                let domain = self.errorDomainForRequest(self.currentRequest)
+                self.error = error.errorByAddingDomain(domain)
+            }
+        }
+        
+        var nextRequest = CAMUploadRequest.nextRequest(self.currentRequest)
+        if self.error != nil || nextRequest == nil
+        {
+            self.currentTaskIdentifier = nil
+            self.state = .Finished
+            
+            return
+        }
+        else if nextRequest == .VideoSettings && self.videoSettings == nil
+        {
+            nextRequest = CAMUploadRequest.nextRequest(nextRequest!)
+            if nextRequest == nil
+            {
+                self.currentTaskIdentifier = nil
+                self.state = .Finished
+                
+                return
+            }
+        }
+        else if nextRequest == .CreateThumbnail && self.thumbnailFileUrl == nil
+        {
+            self.currentTaskIdentifier = nil
+            self.state = .Finished
+            
+            return
+        }
+        
+        do
+        {
+            let sessionManager = sessionManager as! VimeoSessionManager
+            try self.transitionToState(request: nextRequest!, sessionManager: sessionManager)
+            self.resume(sessionManager: sessionManager)
+        }
+        catch let error as NSError
+        {
+            self.error = error
+            self.currentTaskIdentifier = nil
+            self.state = .Finished
+        }
+    }
+    
     // MARK: Private API
     
     private func transitionToState(request request: CAMUploadRequest, sessionManager: VimeoSessionManager) throws
@@ -100,12 +258,65 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
         case .UploadVideo:
             guard let uploadUri = self.uploadTicket?.uploadLinkSecure else
             {
-                throw NSError(domain: UploadErrorDomain.Activate.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to initiate upload but the uploadUri is nil."])
+                throw NSError(domain: UploadErrorDomain.Upload.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to initiate upload but the uploadUri is nil."])
             }
             
-            return try sessionManager.UploadVideoTask(source: self.videoUrl, destination: uploadUri, progress: &self.progress, completionHandler: nil)
+            return try sessionManager.uploadVideoTask(source: self.videoUrl, destination: uploadUri, progress: &self.progress, completionHandler: nil)
+            
         case .ActivateVideo:
-            break
+            guard let activationUri = self.uploadTicket?.completeUri else
+            {
+                throw NSError(domain: UploadErrorDomain.Activate.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Activate response did not contain the required values."])
+            }
+            
+            return try sessionManager.activateVideoDownloadTask(uri: activationUri)
+            
+        case .VideoSettings:
+            guard let videoUri = self.videoUri, let videoSettings = self.videoSettings else
+            {
+                throw NSError(domain: UploadErrorDomain.VideoSettings.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Video settings response did not contain the required values."])
+            }
+            
+            return try sessionManager.videoSettingsDownloadTask(videoUri: videoUri, videoSettings: videoSettings)
+            
+        case .CreateThumbnail:
+            guard let videoUri = self.videoUri else
+            {
+                throw NSError(domain: "CreateVideoThumbnailErrorDomain", code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to create thumbnail resource, but videoUri is nil"])
+            }
+            
+            return try sessionManager.createThumbnailDownloadTask(uri: videoUri)
+            
+        case .UploadThumbnail:
+            guard let thumbnailUploadLink = self.thumbnailTicket?.link, thumbnailFileUrl = self.thumbnailFileUrl else
+            {
+                throw NSError(domain: "UploadVideoThumbnailErrorDomain", code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to initiate thumbnail upload, but thumbnailUploadLink is nil"])
+            }
+            
+            return try sessionManager.uploadThumbnailTask(source: thumbnailFileUrl, destination: thumbnailUploadLink, progress: &self.progress, completionHandler: nil)
+            
+        case .ActivateThumbnail:
+            guard let thumbnailUri = self.thumbnailTicket?.uri else
+            {
+                throw NSError(domain: "ActivateVideoThumbnailErrorDomain", code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to activate thumbnail, but thumbnailUri is nil"])
+            }
+            
+            return try sessionManager.activateThumbnailTask(activationUri: thumbnailUri)
+        }
+    }
+    
+    private func errorDomainForRequest(request: CAMUploadRequest) -> String
+    {
+        switch request
+        {
+        case .CreateVideo:
+            return UploadErrorDomain.Create.rawValue
+        case .UploadVideo:
+            return UploadErrorDomain.Upload.rawValue
+        case .ActivateVideo:
+            return UploadErrorDomain.Activate.rawValue
+        case .VideoSettings:
+            return UploadErrorDomain.VideoSettings.rawValue
         case .CreateThumbnail:
             break
         case .UploadThumbnail:
@@ -113,6 +324,8 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
         case .ActivateThumbnail:
             break
         }
+        
+        return ""
     }
     
     //MARK: NSCoding
@@ -120,7 +333,7 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
     required public init(coder aDecoder: NSCoder)
     {
         self.videoUrl = aDecoder.decodeObjectForKey("videoUrl") as! NSURL
-        self.thumbnailUrl = aDecoder.decodeObjectForKey("thumbnailUrl") as! NSURL
+        self.thumbnailFileUrl = aDecoder.decodeObjectForKey("thumbnailFileUrl") as? NSURL
         self.videoSettings = aDecoder.decodeObjectForKey("videoSettings") as? VideoSettings
         self.uploadTicket = aDecoder.decodeObjectForKey("uploadTicket") as? VIMUploadTicket
         self.currentRequest = CAMUploadRequest(rawValue: aDecoder.decodeObjectForKey("currentRequest") as! String)!
@@ -131,7 +344,7 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
     override public func encodeWithCoder(aCoder: NSCoder)
     {
         aCoder.encodeObject(self.videoUrl, forKey: "videoUrl")
-        aCoder.encodeObject(self.thumbnailUrl, forKey: "thumbnailUrl")
+        aCoder.encodeObject(self.thumbnailFileUrl, forKey: "thumbnailFileUrl")
         aCoder.encodeObject(self.videoSettings, forKey: "videoSettings")
         aCoder.encodeObject(self.uploadTicket, forKey: "uploadTicket")
         aCoder.encodeObject(self.currentRequest.rawValue, forKey: "currentRequest")

--- a/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
@@ -1,0 +1,141 @@
+//
+//  CAMUploadDescriptor.swift
+//  Cameo
+//
+//  Created by Westendorf, Michael on 6/27/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import Foundation
+import VimeoNetworking
+
+//TODO: Once this class is moved into VimeoUpload, we can remove this import.  [MW] 6/27/16
+import VimeoUpload
+
+public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
+{
+    let videoUrl: NSURL
+    let videoSettings: VideoSettings?
+    let thumbnailUrl: NSURL
+    
+    private(set) var uploadTicket: VIMUploadTicket?
+    private(set) var video: VIMVideo?
+    
+    private (set) var currentRequest = CAMUploadRequest.CreateVideo
+    {
+        didSet
+        {
+            print("\(self.currentRequest.rawValue) \(self.identifier)")
+        }
+    }
+    
+    //MARK: VideoDescriptor Protocol
+    
+    public var type: VideoDescriptorType
+    {
+        return .Upload
+    }
+    
+    public var videoUri: VideoUri?
+    {
+        return self.uploadTicket?.video?.uri
+    }
+    
+    public var progressDescriptor: ProgressDescriptor
+    {
+        return self
+    }
+    
+    //MARK: Initializers
+    
+    required public init()
+    {
+        fatalError("default init() should not be used, use init(videoUrl:videoSettings:thumbnailUrl:) instead")
+    }
+    
+    public init(videoUrl: NSURL, videoSettings: VideoSettings? = nil, thumbnailUrl: NSURL)
+    {
+        self.videoUrl = videoUrl
+        self.videoSettings = videoSettings
+        self.thumbnailUrl = thumbnailUrl
+        
+        super.init()
+    }
+    
+    //MARK: Overrides
+    
+    override func prepare(sessionManager sessionManager: AFURLSessionManager) throws
+    {
+        let sessionManager = sessionManager as! VimeoSessionManager
+        
+        do
+        {
+            try self.transitionToState(request: .CreateVideo, sessionManager: sessionManager)
+        }
+        catch let error as NSError
+        {
+            self.currentTaskIdentifier = nil
+            self.error = error
+            self.state = .Finished
+            
+            throw error
+        }
+    }
+    
+    // MARK: Private API
+    
+    private func transitionToState(request request: CAMUploadRequest, sessionManager: VimeoSessionManager) throws
+    {
+        self.currentRequest = request
+        let task = try self.taskForRequest(request: request, sessionManager: sessionManager)
+        self.currentTaskIdentifier = task.taskIdentifier
+    }
+    
+    private func taskForRequest(request request: CAMUploadRequest, sessionManager: VimeoSessionManager) throws -> NSURLSessionTask
+    {
+        switch request
+        {
+        case .CreateVideo:
+            return try sessionManager.createVideoDownloadTask(url: self.videoUrl)
+        case .UploadVideo:
+            guard let uploadUri = self.uploadTicket?.uploadLinkSecure else
+            {
+                throw NSError(domain: UploadErrorDomain.Activate.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to initiate upload but the uploadUri is nil."])
+            }
+            
+            return try sessionManager.UploadVideoTask(source: self.videoUrl, destination: uploadUri, progress: &self.progress, completionHandler: nil)
+        case .ActivateVideo:
+            break
+        case .CreateThumbnail:
+            break
+        case .UploadThumbnail:
+            break
+        case .ActivateThumbnail:
+            break
+        }
+    }
+    
+    //MARK: NSCoding
+    
+    required public init(coder aDecoder: NSCoder)
+    {
+        self.videoUrl = aDecoder.decodeObjectForKey("videoUrl") as! NSURL
+        self.thumbnailUrl = aDecoder.decodeObjectForKey("thumbnailUrl") as! NSURL
+        self.videoSettings = aDecoder.decodeObjectForKey("videoSettings") as? VideoSettings
+        self.uploadTicket = aDecoder.decodeObjectForKey("uploadTicket") as? VIMUploadTicket
+        self.currentRequest = CAMUploadRequest(rawValue: aDecoder.decodeObjectForKey("currentRequest") as! String)!
+        
+        super.init(coder: aDecoder)
+    }
+    
+    override public func encodeWithCoder(aCoder: NSCoder)
+    {
+        aCoder.encodeObject(self.videoUrl, forKey: "videoUrl")
+        aCoder.encodeObject(self.thumbnailUrl, forKey: "thumbnailUrl")
+        aCoder.encodeObject(self.videoSettings, forKey: "videoSettings")
+        aCoder.encodeObject(self.uploadTicket, forKey: "uploadTicket")
+        aCoder.encodeObject(self.currentRequest.rawValue, forKey: "currentRequest")
+        
+        super.encodeWithCoder(aCoder)
+    }
+}

--- a/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadReqest.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadReqest.swift
@@ -1,0 +1,35 @@
+//
+//  CAMUploadReqest.swift
+//  Cameo
+//
+//  Created by Westendorf, Michael on 6/27/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import Foundation
+
+public enum CAMUploadRequest: String
+{
+    case CreateVideo
+    case UploadVideo
+    case ActivateVideo
+    case CreateThumbnail
+    case UploadThumbnail
+    case ActivateThumbnail
+    
+    static func orderedRequests() -> [CAMUploadRequest]
+    {
+        return [.CreateVideo, .UploadVideo, .ActivateVideo, .CreateThumbnail, .UploadThumbnail, .ActivateThumbnail]
+    }
+    
+    static func nextRequest(currentRequest: CAMUploadRequest) -> CAMUploadRequest?
+    {
+        let orderedRequests = CAMUploadRequest.orderedRequests()
+        if let index = orderedRequests.indexOf(currentRequest) where index + 1 < orderedRequests.count
+        {
+            return orderedRequests[index + 1]
+        }
+        
+        return nil
+    }
+}

--- a/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadReqest.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadReqest.swift
@@ -13,13 +13,14 @@ public enum CAMUploadRequest: String
     case CreateVideo
     case UploadVideo
     case ActivateVideo
+    case VideoSettings
     case CreateThumbnail
     case UploadThumbnail
     case ActivateThumbnail
     
     static func orderedRequests() -> [CAMUploadRequest]
     {
-        return [.CreateVideo, .UploadVideo, .ActivateVideo, .CreateThumbnail, .UploadThumbnail, .ActivateThumbnail]
+        return [.CreateVideo, .UploadVideo, .ActivateVideo, .VideoSettings, .CreateThumbnail, .UploadThumbnail, .ActivateThumbnail]
     }
     
     static func nextRequest(currentRequest: CAMUploadRequest) -> CAMUploadRequest?

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoRequestSerializer+Thumbnail.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoRequestSerializer+Thumbnail.swift
@@ -10,7 +10,6 @@ import Foundation
 import AVFoundation
 import VimeoNetworking
 
-
 extension VimeoRequestSerializer
 {
     func createThumbnailRequestWithUri(uri: String) throws -> NSMutableURLRequest
@@ -22,7 +21,7 @@ extension VimeoRequestSerializer
         
         if let error = error
         {
-            throw error.errorByAddingDomain("CreateThumbnailOperationErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.CreateThumbnail.rawValue)
         }
         
         return request
@@ -38,7 +37,7 @@ extension VimeoRequestSerializer
         
         if let error = error
         {
-            throw error.errorByAddingDomain("ActivateThumbnailOperationErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.ActivateThumbnail.rawValue)
         }
         
         return request
@@ -53,7 +52,7 @@ extension VimeoRequestSerializer
         var error: NSError?
         let request = self.requestWithMethod("PUT", URLString: destination, parameters: nil, error: &error)
         if let error = error {
-            throw error.errorByAddingDomain("UploadThumbnailErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.UploadThumbnail.rawValue)
         }
         
         let asset = AVURLAsset(URL: source)
@@ -62,7 +61,7 @@ extension VimeoRequestSerializer
         do {
             fileSize = try asset.fileSize()
         } catch let error as NSError {
-            throw error.errorByAddingDomain("UploadThumbnailErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.UploadThumbnail.rawValue)
         }
         
         request.setValue("\(fileSize)", forHTTPHeaderField: "Content-Length")

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoRequestSerializer+Thumbnail.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoRequestSerializer+Thumbnail.swift
@@ -1,0 +1,58 @@
+//
+//  VimeoRequestSerializer+Thumbnail.swift
+//  Cameo
+//
+//  Created by Westendorf, Michael on 6/23/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import Foundation
+import VimeoNetworking
+import VimeoUpload
+
+extension VimeoRequestSerializer
+{
+    func createThumbnailRequestWithUri(uri: String) throws -> NSMutableURLRequest
+    {
+        let url = NSURL(string: "\(uri)/pictures", relativeToURL: VimeoBaseURLString)!
+        
+        var error: NSError?
+        let request = self.requestWithMethod("POST", URLString: url.absoluteString, parameters: nil, error: &error)
+        
+        if let error = error
+        {
+            throw error.errorByAddingDomain("CreateThumbnailOperationErrorDomain")
+        }
+        
+        return request
+    }
+    
+    func uploadThumbnailRequestWithSource(source: NSURL, destination: String) throws -> NSMutableURLRequest {
+        
+        guard let path = source.path where NSFileManager.defaultManager().fileExistsAtPath(path) else {
+            throw NSError(domain: UploadErrorDomain.Upload.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to construct upload request but the source file does not exist."])
+        }
+        
+        var error: NSError?
+        let request = self.requestWithMethod("PUT", URLString: destination, parameters: nil, error: &error)
+        if let error = error {
+            throw error.errorByAddingDomain(UploadErrorDomain.Upload.rawValue)
+        }
+        
+        let asset = AVURLAsset(URL: source)
+        
+        let fileSize: NSNumber
+        do {
+            fileSize = try asset.fileSize()
+        } catch let error as NSError {
+            throw error.errorByAddingDomain(UploadErrorDomain.Upload.rawValue)
+        }
+        
+        request.setValue("\(fileSize)", forHTTPHeaderField: "Content-Length")
+        request.setValue("image/jpeg", forHTTPHeaderField: "Content-Type")
+        request.setValue("bytes 0-\(fileSize)/\(fileSize)", forHTTPHeaderField: "Content-Range")
+        
+        return request
+    }
+}
+

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoRequestSerializer+Thumbnail.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoRequestSerializer+Thumbnail.swift
@@ -7,8 +7,9 @@
 //
 
 import Foundation
+import AVFoundation
 import VimeoNetworking
-import VimeoUpload
+
 
 extension VimeoRequestSerializer
 {
@@ -27,6 +28,22 @@ extension VimeoRequestSerializer
         return request
     }
     
+    func activateThumbnailRequestWithUri(uri: String) throws -> NSMutableURLRequest
+    {
+        let url = NSURL(string: "\(uri)", relativeToURL: VimeoBaseURLString)!
+        
+        var error: NSError?
+        let activationParams = ["active" : "true"]
+        let request = self.requestWithMethod("PATCH", URLString: url.absoluteString, parameters: activationParams, error: &error)
+        
+        if let error = error
+        {
+            throw error.errorByAddingDomain("ActivateThumbnailOperationErrorDomain")
+        }
+        
+        return request
+    }
+    
     func uploadThumbnailRequestWithSource(source: NSURL, destination: String) throws -> NSMutableURLRequest {
         
         guard let path = source.path where NSFileManager.defaultManager().fileExistsAtPath(path) else {
@@ -36,7 +53,7 @@ extension VimeoRequestSerializer
         var error: NSError?
         let request = self.requestWithMethod("PUT", URLString: destination, parameters: nil, error: &error)
         if let error = error {
-            throw error.errorByAddingDomain(UploadErrorDomain.Upload.rawValue)
+            throw error.errorByAddingDomain("UploadThumbnailErrorDomain")
         }
         
         let asset = AVURLAsset(URL: source)
@@ -45,7 +62,7 @@ extension VimeoRequestSerializer
         do {
             fileSize = try asset.fileSize()
         } catch let error as NSError {
-            throw error.errorByAddingDomain(UploadErrorDomain.Upload.rawValue)
+            throw error.errorByAddingDomain("UploadThumbnailErrorDomain")
         }
         
         request.setValue("\(fileSize)", forHTTPHeaderField: "Content-Length")

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoResponseSerializer+Thumbnail.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoResponseSerializer+Thumbnail.swift
@@ -8,12 +8,9 @@
 
 import Foundation
 import VimeoNetworking
-import VimeoUpload
 
 extension VimeoResponseSerializer
 {
-    private static let LocationKey = "Location"
-    
     func processCreateThumbnailResponse(response: NSURLResponse?, url: NSURL?, error: NSError?) throws -> VIMThumbnailUploadTicket
     {
         let responseObject: [String: AnyObject]?
@@ -23,7 +20,7 @@ extension VimeoResponseSerializer
         }
         catch let error as NSError
         {
-            throw error.errorByAddingDomain("CreateThumbnailErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.CreateThumbnail.rawValue)
         }
         
         return try self.processCreateThumbnailResponse(response, responseObject: responseObject, error: error)
@@ -37,7 +34,7 @@ extension VimeoResponseSerializer
         }
         catch let error as NSError
         {
-            throw error.errorByAddingDomain("CreateThumbnailErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.CreateThumbnail.rawValue)
         }
         
         do
@@ -46,7 +43,7 @@ extension VimeoResponseSerializer
         }
         catch let error as NSError
         {
-            throw error.errorByAddingDomain("CreateThumbnailErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.CreateThumbnail.rawValue)
         }
     }
     
@@ -58,7 +55,7 @@ extension VimeoResponseSerializer
         }
         catch let error as NSError
         {
-            throw error.errorByAddingDomain("UploadThumbnailErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.UploadThumbnail.rawValue)
         }
     }
     
@@ -71,7 +68,7 @@ extension VimeoResponseSerializer
         }
         catch let error as NSError
         {
-            throw error.errorByAddingDomain("ActivateThumbnailErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.ActivateThumbnail.rawValue)
         }
         
         return try self.processActivateThumbnailResponse(response, responseObject: responseObject, error: error)
@@ -85,7 +82,7 @@ extension VimeoResponseSerializer
         }
         catch let error as NSError
         {
-            throw error.errorByAddingDomain("ActivateThumbnailErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.ActivateThumbnail.rawValue)
         }
         
         do
@@ -94,7 +91,7 @@ extension VimeoResponseSerializer
         }
         catch let error as NSError
         {
-            throw error.errorByAddingDomain("CreateThumbnailErrorDomain")
+            throw error.errorByAddingDomain(UploadErrorDomain.CreateThumbnail.rawValue)
         }
     }
     

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoResponseSerializer+Thumbnail.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoResponseSerializer+Thumbnail.swift
@@ -12,12 +12,123 @@ import VimeoUpload
 
 extension VimeoResponseSerializer
 {
-    func processUploadThumbnailResponse(response: NSURLResponse?, responseObject: AnyObject?, error: NSError?) throws {
-        do {
-            try self.checkDataResponseForError(response: response, responseObject: responseObject, error: error)
-        } catch let error as NSError {
-            throw error.errorByAddingDomain(UploadErrorDomain.Upload.rawValue)
+    private static let LocationKey = "Location"
+    
+    func processCreateThumbnailResponse(response: NSURLResponse?, url: NSURL?, error: NSError?) throws -> VIMThumbnailUploadTicket
+    {
+        let responseObject: [String: AnyObject]?
+        do
+        {
+            responseObject = try responseObjectFromDownloadTaskResponse(response: response, url: url, error: error)
+        }
+        catch let error as NSError
+        {
+            throw error.errorByAddingDomain("CreateThumbnailErrorDomain")
+        }
+        
+        return try self.processCreateThumbnailResponse(response, responseObject: responseObject, error: error)
+    }
+    
+    func processCreateThumbnailResponse(response: NSURLResponse?, responseObject: AnyObject?, error: NSError?) throws -> VIMThumbnailUploadTicket
+    {
+        do
+        {
+            try checkDataResponseForError(response: response, responseObject: responseObject, error: error)
+        }
+        catch let error as NSError
+        {
+            throw error.errorByAddingDomain("CreateThumbnailErrorDomain")
+        }
+        
+        do
+        {
+            return try self.thumbnailTicketFromResponseObject(responseObject)
+        }
+        catch let error as NSError
+        {
+            throw error.errorByAddingDomain("CreateThumbnailErrorDomain")
         }
     }
     
+    func processUploadThumbnailResponse(response: NSURLResponse?, responseObject: AnyObject?, error: NSError?) throws
+    {
+        do
+        {
+            try checkDataResponseForError(response: response, responseObject: responseObject, error: error)
+        }
+        catch let error as NSError
+        {
+            throw error.errorByAddingDomain("UploadThumbnailErrorDomain")
+        }
+    }
+    
+    func processActivateThumbnailResponse(response: NSURLResponse?, url: NSURL?, error: NSError?) throws -> VIMPicture
+    {
+        let responseObject: [String: AnyObject]?
+        do
+        {
+            responseObject = try responseObjectFromDownloadTaskResponse(response: response, url: url, error: error)
+        }
+        catch let error as NSError
+        {
+            throw error.errorByAddingDomain("ActivateThumbnailErrorDomain")
+        }
+        
+        return try self.processActivateThumbnailResponse(response, responseObject: responseObject, error: error)
+    }
+    
+    func processActivateThumbnailResponse(response: NSURLResponse?, responseObject: AnyObject?, error: NSError?) throws -> VIMPicture
+    {
+        do
+        {
+            try checkDataResponseForError(response: response, responseObject: responseObject, error: error)
+        }
+        catch let error as NSError
+        {
+            throw error.errorByAddingDomain("ActivateThumbnailErrorDomain")
+        }
+        
+        do
+        {
+            return try self.vimPictureFromResponseObject(responseObject)
+        }
+        catch let error as NSError
+        {
+            throw error.errorByAddingDomain("CreateThumbnailErrorDomain")
+        }
+    }
+    
+    //MARK: Private methods
+    
+    private func thumbnailTicketFromResponseObject(responseObject: AnyObject?) throws -> VIMThumbnailUploadTicket
+    {
+        if let dictionary = responseObject as? [String: AnyObject]
+        {
+            let mapper = VIMObjectMapper()
+            mapper.addMappingClass(VIMThumbnailUploadTicket.self, forKeypath: "")
+            
+            if let thumbnailTicket = mapper.applyMappingToJSON(dictionary) as? VIMThumbnailUploadTicket
+            {
+                return thumbnailTicket
+            }
+        }
+        
+        throw NSError.errorWithDomain(UploadErrorDomain.VimeoResponseSerializer.rawValue, code: nil, description: "Attempt to parse thumbnailTicket object from responseObject failed")
+    }
+    
+    private func vimPictureFromResponseObject(responseObject: AnyObject?) throws -> VIMPicture
+    {
+        if let dictionary = responseObject as? [String: AnyObject]
+        {
+            let mapper = VIMObjectMapper()
+            mapper.addMappingClass(VIMPicture.self, forKeypath: "")
+            
+            if let picture = mapper.applyMappingToJSON(dictionary) as? VIMPicture
+            {
+                return picture
+            }
+        }
+        
+        throw NSError.errorWithDomain(UploadErrorDomain.VimeoResponseSerializer.rawValue, code: nil, description: "Attempt to parse picture object from responseObject failed")
+    }
 }

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoResponseSerializer+Thumbnail.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoResponseSerializer+Thumbnail.swift
@@ -1,0 +1,23 @@
+//
+//  VimeoResponseSerializer+Thumbnail.swift
+//  Cameo
+//
+//  Created by Westendorf, Michael on 6/23/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import Foundation
+import VimeoNetworking
+import VimeoUpload
+
+extension VimeoResponseSerializer
+{
+    func processUploadThumbnailResponse(response: NSURLResponse?, responseObject: AnyObject?, error: NSError?) throws {
+        do {
+            try self.checkDataResponseForError(response: response, responseObject: responseObject, error: error)
+        } catch let error as NSError {
+            throw error.errorByAddingDomain(UploadErrorDomain.Upload.rawValue)
+        }
+    }
+    
+}

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
@@ -1,0 +1,49 @@
+//
+//  VimeoSessionManager+ThumbnailUpload.swift
+//  Cameo
+//
+//  Created by Westendorf, Michael on 6/23/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import Foundation
+
+//typealias ThumbnailTicketCompletionHandler = (thumbnailTicket: VIMThumbnailTicket?, error: NSError?) -> Void
+
+extension VimeoSessionManager
+{
+    func createThumbnailDownloadTask(uri uri: String, completionHandler: ErrorBlock) throws -> NSURLSessionDownloadTask {
+
+        let request = try (self.requestSerializer as! VimeoRequestSerializer).createThumbnailRequestWithUri(uri)
+        
+        let task = self.downloadTaskWithRequest(request, progress: nil, destination: nil, completionHandler: nil)
+        task.taskDescription = "CreateThumbnail"
+        
+        return task
+    }
+    
+    func uploadThumbnailTask(source source: NSURL, destination: String, progress: AutoreleasingUnsafeMutablePointer<NSProgress>?, completionHandler: ErrorBlock?) throws -> NSURLSessionUploadTask
+    {
+        let request = try (self.requestSerializer as! VimeoRequestSerializer).uploadThumbnailRequestWithSource(source, destination: destination)
+
+        //TODO: Figure out what to do with the progress block [MW] 6/23/16
+        let task = self.uploadTaskWithRequest(request, fromFile: source, progress: nil) { [weak self] (response, responseObject, error) in
+            
+            guard let strongSelf = self, completionHandler = completionHandler else {
+                return
+            }
+            
+            do {
+                try (strongSelf.responseSerializer as! VimeoResponseSerializer).processUploadThumbnailResponse(response, responseObject: responseObject, error: error)
+                completionHandler(error: nil)
+            } catch let error as NSError {
+                completionHandler(error: error)
+            }
+            
+        }
+        
+        task.taskDescription = "UploadThumbnail"
+        
+        return task
+    }
+}

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
@@ -7,13 +7,12 @@
 //
 
 import Foundation
-
-//typealias ThumbnailTicketCompletionHandler = (thumbnailTicket: VIMThumbnailTicket?, error: NSError?) -> Void
+import VimeoNetworking
 
 extension VimeoSessionManager
 {
-    func createThumbnailDownloadTask(uri uri: String, completionHandler: ErrorBlock) throws -> NSURLSessionDownloadTask {
-
+    func createThumbnailDownloadTask(uri uri: VideoUri) throws -> NSURLSessionDownloadTask
+    {
         let request = try (self.requestSerializer as! VimeoRequestSerializer).createThumbnailRequestWithUri(uri)
         
         let task = self.downloadTaskWithRequest(request, progress: nil, destination: nil, completionHandler: nil)
@@ -22,7 +21,7 @@ extension VimeoSessionManager
         return task
     }
     
-    func uploadThumbnailTask(source source: NSURL, destination: String, progress: AutoreleasingUnsafeMutablePointer<NSProgress>?, completionHandler: ErrorBlock?) throws -> NSURLSessionUploadTask
+    func uploadThumbnailTask(source source: NSURL, destination: String, progress: AutoreleasingUnsafeMutablePointer<NSProgress?>, completionHandler: ErrorBlock?) throws -> NSURLSessionUploadTask
     {
         let request = try (self.requestSerializer as! VimeoRequestSerializer).uploadThumbnailRequestWithSource(source, destination: destination)
 
@@ -43,6 +42,16 @@ extension VimeoSessionManager
         }
         
         task.taskDescription = "UploadThumbnail"
+        
+        return task
+    }
+    
+    func activateThumbnailTask(activationUri activationUri: String) throws -> NSURLSessionDownloadTask
+    {
+        let request = try (self.requestSerializer as! VimeoRequestSerializer).activateThumbnailRequestWithUri(activationUri)
+        
+        let task = self.downloadTaskWithRequest(request, progress: nil, destination: nil, completionHandler: nil)
+        task.taskDescription = "ActivateThumbnail"
         
         return task
     }

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
@@ -16,7 +16,7 @@ extension VimeoSessionManager
         let request = try (self.requestSerializer as! VimeoRequestSerializer).createThumbnailRequestWithUri(uri)
         
         let task = self.downloadTaskWithRequest(request, progress: nil, destination: nil, completionHandler: nil)
-        task.taskDescription = "CreateThumbnail"
+        task.taskDescription = UploadTaskDescription.CreateThumbnail.rawValue
         
         return task
     }
@@ -24,8 +24,7 @@ extension VimeoSessionManager
     func uploadThumbnailTask(source source: NSURL, destination: String, progress: AutoreleasingUnsafeMutablePointer<NSProgress?>, completionHandler: ErrorBlock?) throws -> NSURLSessionUploadTask
     {
         let request = try (self.requestSerializer as! VimeoRequestSerializer).uploadThumbnailRequestWithSource(source, destination: destination)
-
-        //TODO: Figure out what to do with the progress block [MW] 6/23/16
+        
         let task = self.uploadTaskWithRequest(request, fromFile: source, progress: nil) { [weak self] (response, responseObject, error) in
             
             guard let strongSelf = self, completionHandler = completionHandler else {
@@ -41,7 +40,7 @@ extension VimeoSessionManager
             
         }
         
-        task.taskDescription = "UploadThumbnail"
+        task.taskDescription = UploadTaskDescription.UploadThumbnail.rawValue
         
         return task
     }
@@ -51,7 +50,7 @@ extension VimeoSessionManager
         let request = try (self.requestSerializer as! VimeoRequestSerializer).activateThumbnailRequestWithUri(activationUri)
         
         let task = self.downloadTaskWithRequest(request, progress: nil, destination: nil, completionHandler: nil)
-        task.taskDescription = "ActivateThumbnail"
+        task.taskDescription = UploadTaskDescription.ActivateThumbnail.rawValue
         
         return task
     }

--- a/VimeoUpload/Upload/Extensions/NSError+Upload.swift
+++ b/VimeoUpload/Upload/Extensions/NSError+Upload.swift
@@ -59,6 +59,10 @@ public enum UploadErrorDomain: String
     case DeleteVideoOperation = "DeleteVideoOperationErrorDomain"
     
     case VimeoResponseSerializer = "VimeoResponseSerializerErrorDomain"
+    
+    case CreateThumbnail = "CreateVideoThumbnailErrorDomain"
+    case UploadThumbnail = "UploadVideoThumbnailErrorDomain"
+    case ActivateThumbnail = "ActivateVideoThumbnailErrorDomain"
 }
 
 @objc enum UploadLocalErrorCode: Int

--- a/VimeoUpload/Upload/Networking/Old Upload/VimeoSessionManager+OldUpload.swift
+++ b/VimeoUpload/Upload/Networking/Old Upload/VimeoSessionManager+OldUpload.swift
@@ -37,6 +37,9 @@ enum UploadTaskDescription: String
     case VideoSettings = "VideoSettings"
     case DeleteVideo = "DeleteVideo"
     case Video = "Video"
+    case CreateThumbnail = "CreateThumbnail"
+    case UploadThumbnail = "UploadThumbnail"
+    case ActivateThumbnail = "ActivateThumbnail"
 }
 
 extension VimeoSessionManager


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[CAM-308](https://vimean.atlassian.net/browse/CAM-308)

#### Ticket Summary
Create a new upload descriptor that encapsulates the create / upload / activate video steps and the create / upload / activate thumbnail steps.

#### Implementation Summary
I added a new CAMUploadDescriptor that is based on the OldUploadDescriptor class.  It performs the 4 step upload for video files and adds 3 additional steps for uploading a custom thumbnail.  New extensions for VimeoRequestSerializer, VimeoResponseSerializer, and VimeoSessionManager were added for thumbnail specific request / response handling.

#### How to Test
N/A