### PR TITLE
CAM-XXX: Switch CAMUploadDescriptor to two step upload process

### DIFF
--- a/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadReqest.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadReqest.swift
@@ -12,15 +12,13 @@ public enum CAMUploadRequest: String
 {
     case CreateVideo
     case UploadVideo
-    case ActivateVideo
-    case VideoSettings
     case CreateThumbnail
     case UploadThumbnail
     case ActivateThumbnail
     
     static func orderedRequests() -> [CAMUploadRequest]
     {
-        return [.CreateVideo, .UploadVideo, .ActivateVideo, .VideoSettings, .CreateThumbnail, .UploadThumbnail, .ActivateThumbnail]
+        return [.CreateVideo, .UploadVideo, .CreateThumbnail, .UploadThumbnail, .ActivateThumbnail]
     }
     
     static func nextRequest(currentRequest: CAMUploadRequest) -> CAMUploadRequest?

--- a/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoSessionManager+Upload.swift
+++ b/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoSessionManager+Upload.swift
@@ -59,4 +59,15 @@ extension VimeoSessionManager
         
         return task
     }
+    
+    func createVideoDownloadTask(url url: NSURL, videoSettings: VideoSettings?) throws -> NSURLSessionDownloadTask
+    {
+        let request = try (self.requestSerializer as! VimeoRequestSerializer).createVideoRequestWithUrl(url, videoSettings: videoSettings)
+        
+        let task = self.downloadTaskWithRequest(request, progress: nil, destination: nil, completionHandler: nil)
+        
+        task.taskDescription = UploadTaskDescription.CreateVideo.rawValue
+        
+        return task
+    }
 }


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
N/A

#### Ticket Summary
Need to switch the CAMUploadDescriptor over to using the two step upload process so that we have a valid VIMVideo object in the VIMUploadTicket.

#### Implementation Summary
Added a new method to VimeoSessionManager+Upload so we can get a download task for the create video step.  Modified the CAMUploadDescriptor class to use the two step upload version for the create video step.  Removed the VideoSettings and ActivateVideo steps from the CAMUploadDescriptor.

#### How to Test
N/A

