### PR TITLE
[WIP] VIM-4197: iCloud videos never play back for preview on Upload settings screen	

### DIFF
--- a/VimeoUpload/UIKit/PHAssetHelper.swift
+++ b/VimeoUpload/UIKit/PHAssetHelper.swift
@@ -165,6 +165,25 @@ import Photos
         self.cancelImageRequest(cameraRollAsset: cameraRollAsset)
         self.cancelAssetRequest(cameraRollAsset: cameraRollAsset)
     }
+    
+    // MARK: Static Helpers
+    
+    static func requestPlayerItem(cameraRollAsset: VIMPHAsset, completionHandler: (AVPlayerItem?, NSDictionary?) -> Void)
+    {
+        let phAsset = cameraRollAsset.phAsset
+        
+        let options = PHVideoRequestOptions()
+        options.networkAccessAllowed = true // We do not check for inCloud in resultHandler because we allow network access
+        options.deliveryMode = .HighQualityFormat
+        
+        PHImageManager.defaultManager().requestPlayerItemForVideo(phAsset, options: options, resultHandler: { (playerItem, info) -> Void  in
+            
+            dispatch_async(dispatch_get_main_queue(), {
+                
+                completionHandler(playerItem, info)
+            })
+        })
+    }
 
     // MARK: Private API
 


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-4197](https://vimean.atlassian.net/browse/VIM-4197)

#### Ticket Summary
Added a helper to fetch the `playerItem` for playback, useful for playback of an iCloud video. 

#### Implementation Summary
Wrapped up `requestPlayerItemForVideo` into helper, for which you pass in a phAsset and completion block.

#### How to Test
See parent ticket