### PR TITLE
VIM-4197: Resolve No Playback for iCloud Videos in Upload Preview

### DIFF
--- a/VimeoUpload/Upload/Operations/Async/ExportOperation.swift
+++ b/VimeoUpload/Upload/Operations/Async/ExportOperation.swift
@@ -38,7 +38,7 @@ class ExportOperation: ConcurrentOperation
     private static let ProgressKeyPath = "progress"
     private static let FileType = AVFileTypeMPEG4
 
-    private var exportSession: AVAssetExportSession
+    private(set) var exportSession: AVAssetExportSession
     
     // We KVO on this internally in order to call the progressBlock, see note below as to why [AH] 10/22/2015
     private dynamic var progress: Float = 0

--- a/VimeoUpload/Upload/Operations/Async/ExportQuotaOperation.swift
+++ b/VimeoUpload/Upload/Operations/Async/ExportQuotaOperation.swift
@@ -27,13 +27,15 @@
 import Foundation
 import AVFoundation
 
+typealias ExportProgressBlock = (exportSession: AVAssetExportSession, progress: Double) -> Void
+
 class ExportQuotaOperation: ConcurrentOperation
 {
     let me: VIMUser
     let operationQueue: NSOperationQueue
     
     var downloadProgressBlock: ProgressBlock?
-    var exportProgressBlock: ProgressBlock?
+    var exportProgressBlock: ExportProgressBlock?
     
     var error: NSError?
         {
@@ -97,7 +99,7 @@ class ExportQuotaOperation: ConcurrentOperation
             if let progressBlock = self?.exportProgressBlock
             {
                 dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                    progressBlock(progress: progress)
+                    progressBlock(exportSession: exportOperation.exportSession, progress: progress)
                 })
             }
         }

--- a/VimeoUpload/Upload/Operations/Private/ExportQuotaCreateOperation.swift
+++ b/VimeoUpload/Upload/Operations/Private/ExportQuotaCreateOperation.swift
@@ -37,7 +37,7 @@ class ExportQuotaCreateOperation: ConcurrentOperation
     // MARK:
     
     var downloadProgressBlock: ProgressBlock?
-    var exportProgressBlock: ProgressBlock?
+    var exportProgressBlock: ExportProgressBlock?
     
     // MARK:
     
@@ -113,8 +113,8 @@ class ExportQuotaCreateOperation: ConcurrentOperation
             self?.downloadProgressBlock?(progress: progress)
         }
         
-        operation.exportProgressBlock = { [weak self] (progress: Double) -> Void in
-            self?.exportProgressBlock?(progress: progress)
+        operation.exportProgressBlock = { [weak self] (exportSession: AVAssetExportSession, progress: Double) -> Void in
+            self?.exportProgressBlock?(exportSession: exportSession, progress: progress)
         }
         
         operation.completionBlock = { [weak self] () -> Void in

--- a/VimeoUpload/Upload/Operations/Private/RetryUploadOperation.swift
+++ b/VimeoUpload/Upload/Operations/Private/RetryUploadOperation.swift
@@ -126,7 +126,7 @@ class RetryUploadOperation: ConcurrentOperation
             self?.downloadProgressBlock?(progress: progress)
         }
         
-        operation.exportProgressBlock = { [weak self] (progress: Double) -> Void in
+        operation.exportProgressBlock = { [weak self] (exportSession: AVAssetExportSession, progress: Double) -> Void in
             self?.exportProgressBlock?(progress: progress)
         }
         


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-4197](https://vimean.atlassian.net/browse/VIM-4197)

#### Ticket Summary
The asset for an iCloud video was not readily available for playback after being downloaded. We now pass the export session object into the `exportProgressBlock` so that a client can access the asset from an iCloud video for playback, via `exportSession.asset`.

#### Implementation Summary
- made `exportSession` property on `ExportOperation` accessible outside of class 
- new block type `ExportProgressBlock` includes an `exportSession` object as input parameter
- property `exportProgressBlock` on `ExportQuotaOperation` now has type `ExportProgressBlock` where we pass in the `exportSession`

#### How to Test
See parent ticket. 