### PR TITLE
VIM-4803: Download Crash

### DIFF
--- a/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
@@ -255,7 +255,7 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
                 throw NSError(domain: UploadErrorDomain.Upload.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to initiate upload but the uploadUri is nil."])
             }
             
-            return try sessionManager.uploadVideoTask(source: self.videoUrl, destination: uploadUri, progress: &self.progress, completionHandler: nil)
+            return try sessionManager.uploadVideoTask(source: self.videoUrl, destination: uploadUri, completionHandler: nil)
             
         case .CreateThumbnail:
             guard let videoUri = self.uploadTicket?.video?.uri else
@@ -271,7 +271,7 @@ public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor
                 throw NSError(domain: UploadErrorDomain.UploadThumbnail.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to initiate thumbnail upload, but thumbnailUploadLink is nil"])
             }
             
-            return try sessionManager.uploadThumbnailTask(source: thumbnailUrl, destination: thumbnailUploadLink, progress: &self.progress, completionHandler: nil)
+            return try sessionManager.uploadThumbnailTask(source: thumbnailUrl, destination: thumbnailUploadLink, completionHandler: nil)
             
         case .ActivateThumbnail:
             guard let thumbnailUri = self.pictureTicket?.uri else

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
@@ -21,7 +21,7 @@ extension VimeoSessionManager
         return task
     }
     
-    func uploadThumbnailTask(source source: NSURL, destination: String, progress: AutoreleasingUnsafeMutablePointer<NSProgress?>, completionHandler: ErrorBlock?) throws -> NSURLSessionUploadTask
+    func uploadThumbnailTask(source source: NSURL, destination: String, completionHandler: ErrorBlock?) throws -> NSURLSessionUploadTask
     {
         let request = try (self.requestSerializer as! VimeoRequestSerializer).uploadThumbnailRequestWithSource(source, destination: destination)
         

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -87,7 +87,7 @@ public class UploadDescriptor: ProgressDescriptor, VideoDescriptor
             }
             
             let sessionManager = sessionManager as! VimeoSessionManager
-            let task = try sessionManager.uploadVideoTask(source: self.url, destination: uploadLinkSecure, progress: &self.progress, completionHandler: nil)
+            let task = try sessionManager.uploadVideoTask(source: self.url, destination: uploadLinkSecure, completionHandler: nil)
             
             self.currentTaskIdentifier = task.taskIdentifier
         }

--- a/VimeoUpload/Upload/Descriptor System/Old Upload/OldUploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/Old Upload/OldUploadDescriptor.swift
@@ -239,7 +239,7 @@ public class OldUploadDescriptor: ProgressDescriptor, VideoDescriptor
                 throw NSError(domain: UploadErrorDomain.Upload.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Attempt to initiate upload but the uploadUri is nil."])
             }
 
-            return try sessionManager.uploadVideoTask(source: self.url, destination: uploadUri, progress: &self.progress, completionHandler: nil)
+            return try sessionManager.uploadVideoTask(source: self.url, destination: uploadUri, completionHandler: nil)
             
         case .Activate:
             guard let activationUri = self.uploadTicket?.completeUri else

--- a/VimeoUpload/Upload/Networking/Old Upload/VimeoSessionManager+OldUpload.swift
+++ b/VimeoUpload/Upload/Networking/Old Upload/VimeoSessionManager+OldUpload.swift
@@ -117,15 +117,11 @@ extension VimeoSessionManager
         return task
     }
     
-    func uploadVideoTask(source source: NSURL, destination: String, progress: AutoreleasingUnsafeMutablePointer<NSProgress?>, completionHandler: ErrorBlock?) throws -> NSURLSessionUploadTask
+    func uploadVideoTask(source source: NSURL, destination: String, completionHandler: ErrorBlock?) throws -> NSURLSessionUploadTask
     {
         let request = try (self.requestSerializer as! VimeoRequestSerializer).uploadVideoRequestWithSource(source, destination: destination)
         
-        let task = self.uploadTaskWithRequest(request, fromFile: source, progress: {(progress) -> Void in
-            
-            // TODO: Do something with progress block [AH] 4/25/2016
-            
-        }, completionHandler: { [weak self] (response, responseObject, error) -> Void in
+        let task = self.uploadTaskWithRequest(request, fromFile: source, progress: nil, completionHandler: { [weak self] (response, responseObject, error) -> Void in
 
             guard let strongSelf = self, let completionHandler = completionHandler else
             {


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-4803](https://vimean.atlassian.net/browse/VIM-4803)

#### Ticket Summary
We were experiencing a memory / potentially zombie induced crash upon initiating one or more downloads. 

#### Implementation Summary
There were API changes in AFNetworking that made the progress object more accessible via a block. https://github.com/AFNetworking/AFNetworking/pull/3187
 
Our own API included a means to pass in an `AutoreleasingUnsafeMutablePointer<NSProgress?>` to keep track of this progress, if needed. 

Because we don't need to maintain a pointer to this progress object in our current implementation, and just discovered that doing so can introduce bugs, we removed this part of the API. 

#### How to Test
See parent ticket.
