### PR TITLE
VIM-XXXX: 6.1.4 NSKeyedArchiver Migration Bug

### DIFF
--- a/VimeoUpload/Descriptor System/KeyedArchiver.swift
+++ b/VimeoUpload/Descriptor System/KeyedArchiver.swift
@@ -35,11 +35,11 @@ public class KeyedArchiver: ArchiverProtocol
 
     public init(basePath: String)
     {
+        self.dynamicType.setLegacyClassNameMigrations()
+
         assert(NSFileManager.defaultManager().fileExistsAtPath(basePath, isDirectory: nil), "Invalid basePath")
         
         self.basePath = basePath
-        
-        self.setLegacyClassNameMigrations()
     }
     
     public func loadObjectForKey(key: String) -> AnyObject?
@@ -73,7 +73,7 @@ public class KeyedArchiver: ArchiverProtocol
 
 private extension KeyedArchiver
 {
-    private func setLegacyClassNameMigrations()
+    private static func setLegacyClassNameMigrations()
     {
         // This appeared to only be necessary for downloaded videos with archived VIMVideoFile's that persisted in a failed state. [NL] 05/15/16
         // E.g. a user has at least one failed download with our legacy VIMVideoFile model, then upgrades to this version.


### PR DESCRIPTION
#### Ticket

N/A

#### Ticket Summary

6.1.4 was sometimes crashing every time you opened the app after migrating from 6.1.3.

#### Implementation Summary

This was happening because of a NSKeyedArchiver migration problem when updating the app with an upload in a failed state. See the comment in the code for a description of the problem.

#### How to Test

- Download 6.1.3 from the app store
- Upload a video and force quit the app halfway through so it's in a failed "retry" state
- Download 6.1.4
- Make sure the app opens