### PR TITLE
CI-123 PR build reporting

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,5 @@
-xcode_summary.ignored_files = '**/Pods/**'
-xcode_summary.report 'build/reports/errors.json'
+xcode_summary.ignored_files = 'Pods/*'
+Dir.glob('build/reports/errors-*.json') do |result|
+    xcode_summary.report result
+end
 markdown "See build details on [CircleCI](#{ENV['CIRCLE_BUILD_URL']})"

--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ dependencies:
 
 test:
   override:
-    - bundle exec fastlane test
+    - FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane test

--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,8 @@ machine:
 
 dependencies:
     override:
-        - bundle install
+        - bundle install --deployment
     cache_directories:
-        - "Pods"
         - "vendor/bundle"
 
 test:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,6 +50,8 @@ platform :ios do
   lane :run_test do |options|
     # Work-around to hanging simulators
     ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR'] = "1"
+    # custom paths for xcpretty-formatter; see Dangerfile
+    ENV['XCPRETTY_JSON_FILE_OUTPUT'] = "build/reports/errors-#{options[:scheme]}.json"
     scan(
       workspace: "VimeoUpload.xcworkspace",
       scheme: options[:scheme],


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[CI-123](https://vimean.atlassian.net/browse/CI-123)

#### Ticket Summary
Report build results to PR comments. This feature was in already, but because there were two "builds" - iOS and iOS-Old, they were overwriting each other. This PR fixes that by separating the reports.

#### Implementation Summary
Updated Fastlane and Danger to generate and read separate build reports.

#### How to Test
PR comment should include 2 separate reports.