### PR TITLE
AF-126: Fix crash on PHImageManager.default()

### DIFF
--- a/VimeoUpload/UIKit/PHAssetHelper.swift
+++ b/VimeoUpload/UIKit/PHAssetHelper.swift
@@ -31,7 +31,6 @@ import Photos
 {
     static let ErrorDomain = "PHAssetHelperErrorDomain"
     
-    private let imageManager = PHImageManager.default()
     private var activeImageRequests: [String: PHImageRequestID] = [:]
     private var activeAssetRequests: [String: PHImageRequestID] = [:]
 
@@ -41,13 +40,13 @@ import Photos
         
         for requestID in self.activeImageRequests.values
         {
-            self.imageManager.cancelImageRequest(requestID)
+            PHImageManager.default().cancelImageRequest(requestID)
         }
         self.activeImageRequests.removeAll()
         
         for requestID in self.activeAssetRequests.values
         {
-            self.imageManager.cancelImageRequest(requestID)
+            PHImageManager.default().cancelImageRequest(requestID)
         }
         self.activeAssetRequests.removeAll()
     }
@@ -67,7 +66,7 @@ import Photos
         options.version = .current
         options.resizeMode = .fast
         
-        let requestID = self.imageManager.requestImage(for: phAsset, targetSize: scaledSize, contentMode: .aspectFill, options: options, resultHandler: { [weak self] (image, info) -> Void in
+        let requestID = PHImageManager.default().requestImage(for: phAsset, targetSize: scaledSize, contentMode: .aspectFill, options: options, resultHandler: { [weak self] (image, info) -> Void in
             
             guard let strongSelf = self else
             {
@@ -116,7 +115,7 @@ import Photos
         options.isNetworkAccessAllowed = false
         options.deliveryMode = .highQualityFormat
         
-        let requestID = self.imageManager.requestAVAsset(forVideo: phAsset, options: options) { [weak self] (asset, audioMix, info) -> Void in
+        let requestID = PHImageManager.default().requestAVAsset(forVideo: phAsset, options: options) { [weak self] (asset, audioMix, info) -> Void in
             
             if let info = info, let cancelled = info[PHImageCancelledKey] as? Bool, cancelled == true
             {
@@ -174,7 +173,7 @@ import Photos
         
         if let requestID = self.activeImageRequests[phAsset.localIdentifier]
         {
-            self.imageManager.cancelImageRequest(requestID)
+            PHImageManager.default().cancelImageRequest(requestID)
             self.activeImageRequests.removeValue(forKey: phAsset.localIdentifier)
         }
     }
@@ -185,7 +184,7 @@ import Photos
         
         if let requestID = self.activeAssetRequests[phAsset.localIdentifier]
         {
-            self.imageManager.cancelImageRequest(requestID)
+            PHImageManager.default().cancelImageRequest(requestID)
             self.activeAssetRequests.removeValue(forKey: phAsset.localIdentifier)
         }
     }


### PR DESCRIPTION
#### Ticket

[AF-126](https://vimean.atlassian.net/browse/AF-126)

#### Ticket Summary

We used to store `PHImageManager.default()` in a property `imageManager`. The line that instantiate this property `imageManager` always gets called when we hit on the `Upload` button. In other words, every time we access to `PHAssetHelper`.

A crash would occur if there is a memory warning and the authorization to access to the library was turned off.

Note: In sync with the last comment on this post:
https://stackoverflow.com/questions/33266346/photos-framework-crash-this-application-is-not-allowed-to-access-photo-data

#### Implementation Summary

Completely removed the property and directly call `PHImageManager.default()` when needed.

#### How to Test

- Run the main app on simulator
- Have the authorization to access to the Photo Library turned off. (go to settings, vimeo app, toggle off the `Photo Library`)
- Hit on the `upload button`, last tab
- In the simulator menu, hit on hardware > Simulate Memory Warning.
- Make sure the app doesn't crash.