### PR TITLE
AF-105: Fix Upload Example Crash

### DIFF
--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
@@ -285,7 +285,7 @@ class VideoSettingsViewController: UIViewController, UITextFieldDelegate
     
     private func applyVideoSettings()
     {
-        guard let videoUri = self.uploadTicket?.video?.uri, let videoSettings = self.videoSettings else
+        guard let videoURI = self.uploadTicket?.video?.uri, let videoSettings = self.videoSettings else
         {
             let alertController = UIAlertController(
                 title: "Cannot Upload Video",
@@ -302,7 +302,7 @@ class VideoSettingsViewController: UIViewController, UITextFieldDelegate
         
         do
         {
-            self.task = try NewVimeoUploader.sharedInstance.foregroundSessionManager.videoSettingsDataTask(videoUri: videoUri, videoSettings: videoSettings, completionHandler: { [weak self] (video, error) -> Void in
+            self.task = try NewVimeoUploader.sharedInstance.foregroundSessionManager.videoSettingsDataTask(videoUri: videoURI, videoSettings: videoSettings, completionHandler: { [weak self] (video, error) -> Void in
                 
                 self?.task = nil
                 

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
@@ -42,6 +42,16 @@ import VimeoUpload
 
 class VideoSettingsViewController: UIViewController, UITextFieldDelegate
 {
+    private struct Constants
+    {
+        struct TwoStepUploadPermissionAlert
+        {
+            static let Title = "Cannot Upload Video"
+            static let Message = "Two-step upload is not available to third-party apps yet!"
+            static let ActionTitle = "OK"
+        }
+    }
+    
     static let UploadInitiatedNotification = "VideoSettingsViewControllerUploadInitiatedNotification"
     static let NibName = "VideoSettingsViewController"
     private static let PreUploadViewPrivacy = "pre_upload"
@@ -288,11 +298,11 @@ class VideoSettingsViewController: UIViewController, UITextFieldDelegate
         guard let videoURI = self.uploadTicket?.video?.uri, let videoSettings = self.videoSettings else
         {
             let alertController = UIAlertController(
-                title: "Cannot Upload Video",
-                message: "The video object in `uploadTicket` does not exist!",
+                title: Constants.TwoStepUploadPermissionAlert.Title,
+                message: Constants.TwoStepUploadPermissionAlert.Message,
                 preferredStyle: .alert
             )
-            alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: { [weak self] (action) in
+            alertController.addAction(UIAlertAction(title: Constants.TwoStepUploadPermissionAlert.ActionTitle, style: .default, handler: { [weak self] (action) in
                 self?.activityIndicatorView.stopAnimating()
             }))
             self.present(alertController, animated: true, completion: nil)

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
@@ -287,6 +287,16 @@ class VideoSettingsViewController: UIViewController, UITextFieldDelegate
     {
         guard let videoUri = self.uploadTicket?.video?.uri, let videoSettings = self.videoSettings else
         {
+            let alertController = UIAlertController(
+                title: "Cannot Upload Video",
+                message: "The video object in `uploadTicket` does not exist!",
+                preferredStyle: .alert
+            )
+            alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: { [weak self] (action) in
+                self?.activityIndicatorView.stopAnimating()
+            }))
+            self.present(alertController, animated: true, completion: nil)
+            
             return
         }
         

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
@@ -285,8 +285,10 @@ class VideoSettingsViewController: UIViewController, UITextFieldDelegate
     
     private func applyVideoSettings()
     {
-        let videoUri = self.uploadTicket!.video!.uri!
-        let videoSettings = self.videoSettings!
+        guard let videoUri = self.uploadTicket?.video?.uri, let videoSettings = self.videoSettings else
+        {
+            return
+        }
         
         do
         {

--- a/VimeoUpload/Upload/Model/VideoSettings.swift
+++ b/VimeoUpload/Upload/Model/VideoSettings.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 
-public class VideoSettings: NSObject
+public class VideoSettings: NSObject, NSCoding
 {
     public var title: String?
     {
@@ -104,7 +104,7 @@ public class VideoSettings: NSObject
         self.password = aDecoder.decodeObject(forKey: "password") as? String
     }
     
-    func encode(with aCoder: NSCoder)
+    public func encode(with aCoder: NSCoder)
     {
         aCoder.encode(self.title, forKey: "title")
         aCoder.encode(self.desc, forKey: "desc")


### PR DESCRIPTION
#### Ticket

[AF-105](https://vimean.atlassian.net/browse/AF-105)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR fixes the crashes occurring while attempting to upload a video via the sample app. Originally, the crash was reported for `VimeoUpload` target, which implements the two-step upload flow. Since two-step upload hasn't been available to the public yet, it was found that any current attempt to upload via this flow would not have the video object returned. That behavior caused the crash that multiple people have reported because the flow assumed the video object was always there. The change in the `VimeoUpload` target addresses this issue by safely unwrapping the video object &mdash; if it does not exist, then we show an alert to the user and not execute the remaining logic.

In addition, it was discovered that there was another bug in the four-step upload flow that caused a crash when attempting to upload. The crash occurred because the run-time did not recognize the `encode(with aCoder: NSCoder)` method from the `VimeoUpload` class. This was a direct result from the Swift 3 conversion. This PR also includes a fix to this issue.

#### Implementation Summary

- For the crash in the two-step flow, the video object is now safely unwrapped using `guard let`.
- For the crash in the four-step flow, `VimeoUpload` now conforms to `NSCoding` protocol. Because of that, `encode(with aCoder: NSCoder)` is now `public`, thus making it recognizable to the runtime.

#### Reviewer Tips

For the four-step upload flow, make sure you use a token that has `edit` and `upload` scope.

#### How to Test

- Make sure the two-step upload flow is not available to any third-party access token.
- Make sure the four-step upload flow is able to upload a video with an access token whose scopes include `upload` and `edit`.