### PR TITLE
Change Alert Text of Two-Step Upload Flow

### DIFF
--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
@@ -47,7 +47,7 @@ class VideoSettingsViewController: UIViewController, UITextFieldDelegate
         struct TwoStepUploadPermissionAlert
         {
             static let Title = "Cannot Upload Video"
-            static let Message = "Check the project target to confirm you selected Old-Upload. New-upload is not available to third-party apps yet."
+            static let Message = "Check the project target to confirm you selected Old-Upload. New-Upload is not available to third-party apps yet."
             static let ActionTitle = "OK"
         }
     }

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/ViewControllers/VideoSettingsViewController.swift
@@ -47,7 +47,7 @@ class VideoSettingsViewController: UIViewController, UITextFieldDelegate
         struct TwoStepUploadPermissionAlert
         {
             static let Title = "Cannot Upload Video"
-            static let Message = "Two-step upload is not available to third-party apps yet!"
+            static let Message = "Check the project target to confirm you selected Old-Upload. New-upload is not available to third-party apps yet."
             static let ActionTitle = "OK"
         }
     }


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR contains a new text for the alert appearing when the user attempts to upload a video via the two-step flow.

#### Implementation Summary

N/A

#### Reviewer Tips

N/A

#### How to Test

- Run the example with a third-party token and attempt to upload a video; make sure the new text is on the alert.