### PR TITLE
Inject the shared container identifier string

### DIFF
--- a/VimeoUpload/Descriptor System/ReachableDescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/ReachableDescriptorManager.swift
@@ -47,9 +47,11 @@ import VimeoNetworking
     
     // MARK: - Initialization
     
-    public init(name: String, backgroundSessionIdentifier: String, descriptorManagerDelegate: DescriptorManagerDelegate? = nil, accessTokenProvider: @escaping VimeoRequestSerializer.AccessTokenProvider)
+    public init(name: String, backgroundSessionIdentifier: String, sharedContainerIdentifier: String? = nil, descriptorManagerDelegate: DescriptorManagerDelegate? = nil, accessTokenProvider: @escaping VimeoRequestSerializer.AccessTokenProvider)
     {
         let backgroundSessionManager = VimeoSessionManager.backgroundSessionManager(identifier: backgroundSessionIdentifier, baseUrl: VimeoBaseURL, accessTokenProvider: accessTokenProvider)
+        
+        backgroundSessionManager.session.configuration.sharedContainerIdentifier = sharedContainerIdentifier
         
         super.init(sessionManager: backgroundSessionManager, name: name, delegate: descriptorManagerDelegate)
         


### PR DESCRIPTION
#### Ticket

N/A

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR assigns the shared container identifier to the upload background session's configuration. It is necessary to do so because Apple requires share extensions to have an upload background session to be associated with a shared container.

#### Implementation Summary

##### `ReachableDescriptorManager.swift`

Added a shared container identifier argument to `ReachableDescriptorManager`'s constructor. In the constructor, we then set the identifier to the background configuration's `sharedContainerIdentifier` property.

#### Reviewer Tips

N/A

#### How to Test

N/A
