### PR TITLE
 VIM-6144: Support pre upload for API v3.4

### DIFF
--- a/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
+++ b/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3C53EC271D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC221D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift */; };
 		3C53EC281D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */; };
 		3EA2DAD81DFF3E0F006E2C65 /* ExportSessionOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA2DAD51DFF3E0F006E2C65 /* ExportSessionOperation.swift */; };
+		3EC62D4E2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC62D4D2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift */; };
 		5C9E3CA51EA66187000D1F6B /* DescriptorKVObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9E3CA41EA66187000D1F6B /* DescriptorKVObserver.swift */; };
 		8D9A15BCC5ABADC2D001B20C /* Pods_VimeoUpload.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D4E8D665288660F1F668B91 /* Pods_VimeoUpload.framework */; };
 		AF40D4E51CCE9CB600753ABA /* VimeoUpload.h in Headers */ = {isa = PBXBuildFile; fileRef = AF40D4E41CCE9CB600753ABA /* VimeoUpload.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -51,7 +52,6 @@
 		AF40D5731CCE9DEB00753ABA /* VideoSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF40D52A1CCE9DEB00753ABA /* VideoSettings.swift */; };
 		AF40D5741CCE9DEB00753ABA /* VimeoRequestSerializer+Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF40D52D1CCE9DEB00753ABA /* VimeoRequestSerializer+Upload.swift */; };
 		AF40D5751CCE9DEB00753ABA /* VimeoSessionManager+Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF40D52E1CCE9DEB00753ABA /* VimeoSessionManager+Upload.swift */; };
-		AF40D5761CCE9DEB00753ABA /* VimeoRequestSerializer+OldUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF40D5301CCE9DEB00753ABA /* VimeoRequestSerializer+OldUpload.swift */; };
 		AF40D5771CCE9DEB00753ABA /* VimeoResponseSerializer+OldUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF40D5311CCE9DEB00753ABA /* VimeoResponseSerializer+OldUpload.swift */; };
 		AF40D5781CCE9DEB00753ABA /* VimeoSessionManager+OldUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF40D5321CCE9DEB00753ABA /* VimeoSessionManager+OldUpload.swift */; };
 		AF40D5791CCE9DEB00753ABA /* ConcurrentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF40D5351CCE9DEB00753ABA /* ConcurrentOperation.swift */; };
@@ -84,6 +84,7 @@
 		3C53EC221D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoResponseSerializer+Thumbnail.swift"; path = "Cameo/VimeoResponseSerializer+Thumbnail.swift"; sourceTree = "<group>"; };
 		3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoSessionManager+ThumbnailUpload.swift"; path = "Cameo/VimeoSessionManager+ThumbnailUpload.swift"; sourceTree = "<group>"; };
 		3EA2DAD51DFF3E0F006E2C65 /* ExportSessionOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExportSessionOperation.swift; sourceTree = "<group>"; };
+		3EC62D4D2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoRequestSerializer+SharedUpload.swift"; path = "../Shared/VimeoRequestSerializer+SharedUpload.swift"; sourceTree = "<group>"; };
 		4D4E8D665288660F1F668B91 /* Pods_VimeoUpload.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoUpload.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C9E3CA41EA66187000D1F6B /* DescriptorKVObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescriptorKVObserver.swift; sourceTree = "<group>"; };
 		AF40D4E11CCE9CB600753ABA /* VimeoUpload.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VimeoUpload.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -125,7 +126,6 @@
 		AF40D52A1CCE9DEB00753ABA /* VideoSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoSettings.swift; sourceTree = "<group>"; };
 		AF40D52D1CCE9DEB00753ABA /* VimeoRequestSerializer+Upload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VimeoRequestSerializer+Upload.swift"; sourceTree = "<group>"; };
 		AF40D52E1CCE9DEB00753ABA /* VimeoSessionManager+Upload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VimeoSessionManager+Upload.swift"; sourceTree = "<group>"; };
-		AF40D5301CCE9DEB00753ABA /* VimeoRequestSerializer+OldUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VimeoRequestSerializer+OldUpload.swift"; sourceTree = "<group>"; };
 		AF40D5311CCE9DEB00753ABA /* VimeoResponseSerializer+OldUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VimeoResponseSerializer+OldUpload.swift"; sourceTree = "<group>"; };
 		AF40D5321CCE9DEB00753ABA /* VimeoSessionManager+OldUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VimeoSessionManager+OldUpload.swift"; sourceTree = "<group>"; };
 		AF40D5351CCE9DEB00753ABA /* ConcurrentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentOperation.swift; sourceTree = "<group>"; };
@@ -171,6 +171,15 @@
 				3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */,
 			);
 			name = "Cameo (Private)";
+			sourceTree = "<group>";
+		};
+		3EC62D4C2087D7FB001E8C00 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				3EC62D4D2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift */,
+			);
+			name = Shared;
+			path = "New Group1";
 			sourceTree = "<group>";
 		};
 		5DE6B4A5D1C90E1783FCACAB /* Pods */ = {
@@ -367,6 +376,7 @@
 		AF40D52B1CCE9DEB00753ABA /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				3EC62D4C2087D7FB001E8C00 /* Shared */,
 				AF40D52C1CCE9DEB00753ABA /* New Upload (Private) */,
 				AF40D52F1CCE9DEB00753ABA /* Old Upload */,
 			);
@@ -385,7 +395,6 @@
 		AF40D52F1CCE9DEB00753ABA /* Old Upload */ = {
 			isa = PBXGroup;
 			children = (
-				AF40D5301CCE9DEB00753ABA /* VimeoRequestSerializer+OldUpload.swift */,
 				AF40D5311CCE9DEB00753ABA /* VimeoResponseSerializer+OldUpload.swift */,
 				AF40D5321CCE9DEB00753ABA /* VimeoSessionManager+OldUpload.swift */,
 			);
@@ -580,7 +589,6 @@
 				AF40D5841CCE9DEB00753ABA /* CreateVideoOperation.swift in Sources */,
 				AF40D5831CCE9DEB00753ABA /* VideoOperation.swift in Sources */,
 				AF40D56B1CCE9DEB00753ABA /* VideoDescriptor.swift in Sources */,
-				AF40D5761CCE9DEB00753ABA /* VimeoRequestSerializer+OldUpload.swift in Sources */,
 				AF40D58A1CCE9DEB00753ABA /* RetryUploadOperation.swift in Sources */,
 				AF40D5671CCE9DEB00753ABA /* DescriptorManagerTracker.swift in Sources */,
 				AF40D5681CCE9DEB00753ABA /* UploadDescriptor.swift in Sources */,
@@ -593,6 +601,7 @@
 				AF40D57A1CCE9DEB00753ABA /* DeleteVideoOperation.swift in Sources */,
 				AF40D5851CCE9DEB00753ABA /* ExportSessionExportCreateVideoOperation.swift in Sources */,
 				3C53EC251D219C8500B7AA6D /* CAMUploadReqest.swift in Sources */,
+				3EC62D4E2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift in Sources */,
 				AF40D5571CCE9DEB00753ABA /* KeyedArchiver.swift in Sources */,
 				AF40D5661CCE9DEB00753ABA /* VideoRefreshManager.swift in Sources */,
 				AF40D5541CCE9DEB00753ABA /* DescriptorManager.swift in Sources */,

--- a/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
+++ b/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		3C53EC271D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC221D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift */; };
 		3C53EC281D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */; };
 		3EA2DAD81DFF3E0F006E2C65 /* ExportSessionOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA2DAD51DFF3E0F006E2C65 /* ExportSessionOperation.swift */; };
-		3EC62D4E2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC62D4D2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift */; };
+		3EC62D8D208E8D7B001E8C00 /* VimeoRequestSerializer+SharedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC62D8C208E8D7B001E8C00 /* VimeoRequestSerializer+SharedUpload.swift */; };
 		5C9E3CA51EA66187000D1F6B /* DescriptorKVObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9E3CA41EA66187000D1F6B /* DescriptorKVObserver.swift */; };
 		8D9A15BCC5ABADC2D001B20C /* Pods_VimeoUpload.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D4E8D665288660F1F668B91 /* Pods_VimeoUpload.framework */; };
 		AF40D4E51CCE9CB600753ABA /* VimeoUpload.h in Headers */ = {isa = PBXBuildFile; fileRef = AF40D4E41CCE9CB600753ABA /* VimeoUpload.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -84,7 +84,7 @@
 		3C53EC221D219C8500B7AA6D /* VimeoResponseSerializer+Thumbnail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoResponseSerializer+Thumbnail.swift"; path = "Cameo/VimeoResponseSerializer+Thumbnail.swift"; sourceTree = "<group>"; };
 		3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoSessionManager+ThumbnailUpload.swift"; path = "Cameo/VimeoSessionManager+ThumbnailUpload.swift"; sourceTree = "<group>"; };
 		3EA2DAD51DFF3E0F006E2C65 /* ExportSessionOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExportSessionOperation.swift; sourceTree = "<group>"; };
-		3EC62D4D2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoRequestSerializer+SharedUpload.swift"; path = "../Shared/VimeoRequestSerializer+SharedUpload.swift"; sourceTree = "<group>"; };
+		3EC62D8C208E8D7B001E8C00 /* VimeoRequestSerializer+SharedUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VimeoRequestSerializer+SharedUpload.swift"; sourceTree = "<group>"; };
 		4D4E8D665288660F1F668B91 /* Pods_VimeoUpload.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoUpload.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C9E3CA41EA66187000D1F6B /* DescriptorKVObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescriptorKVObserver.swift; sourceTree = "<group>"; };
 		AF40D4E11CCE9CB600753ABA /* VimeoUpload.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VimeoUpload.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -173,13 +173,12 @@
 			name = "Cameo (Private)";
 			sourceTree = "<group>";
 		};
-		3EC62D4C2087D7FB001E8C00 /* Shared */ = {
+		3EC62D8B208E8D7B001E8C00 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
-				3EC62D4D2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift */,
+				3EC62D8C208E8D7B001E8C00 /* VimeoRequestSerializer+SharedUpload.swift */,
 			);
-			name = Shared;
-			path = "New Group1";
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		5DE6B4A5D1C90E1783FCACAB /* Pods */ = {
@@ -376,7 +375,7 @@
 		AF40D52B1CCE9DEB00753ABA /* Networking */ = {
 			isa = PBXGroup;
 			children = (
-				3EC62D4C2087D7FB001E8C00 /* Shared */,
+				3EC62D8B208E8D7B001E8C00 /* Shared */,
 				AF40D52C1CCE9DEB00753ABA /* New Upload (Private) */,
 				AF40D52F1CCE9DEB00753ABA /* Old Upload */,
 			);
@@ -601,7 +600,7 @@
 				AF40D57A1CCE9DEB00753ABA /* DeleteVideoOperation.swift in Sources */,
 				AF40D5851CCE9DEB00753ABA /* ExportSessionExportCreateVideoOperation.swift in Sources */,
 				3C53EC251D219C8500B7AA6D /* CAMUploadReqest.swift in Sources */,
-				3EC62D4E2087D82D001E8C00 /* VimeoRequestSerializer+SharedUpload.swift in Sources */,
+				3EC62D8D208E8D7B001E8C00 /* VimeoRequestSerializer+SharedUpload.swift in Sources */,
 				AF40D5571CCE9DEB00753ABA /* KeyedArchiver.swift in Sources */,
 				AF40D5661CCE9DEB00753ABA /* VideoRefreshManager.swift in Sources */,
 				AF40D5541CCE9DEB00753ABA /* DescriptorManager.swift in Sources */,

--- a/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
+++ b/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
@@ -33,11 +33,23 @@ extension VimeoRequestSerializer
     {
         static let PreUploadKey = "_pre_upload"
         static let PreUploadDefaultValue = true
+        static let ApproachKey = "approach"
+        static let ApproachDefaultValue = "streaming"
+        static let UploadKey = "upload"
     }
     
     func createVideoRequest(with url: URL, videoSettings: VideoSettings?) throws -> NSMutableURLRequest
     {
-        var parameters = try self.createVideoRequestBaseParameters(url: url)
+        // Create a dictionary containing the file size parameters
+        var uploadParameters = try self.createFileSizeParameters(url: url)
+        
+        // Add on the key-value pair for approach type
+        uploadParameters[Constants.ApproachKey] = Constants.ApproachDefaultValue
+        
+        // Store `uploadParameters` dictionary as the value to "upload" key inside `parameters` dictionary.
+        var parameters = [Constants.UploadKey : uploadParameters as Any]
+        
+        // Add on pre-upload key-value pair to `parameters` dictionary.
         parameters[Constants.PreUploadKey] = Constants.PreUploadDefaultValue
         
         if let videoSettings = videoSettings

--- a/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
+++ b/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
@@ -29,10 +29,16 @@ import VimeoNetworking
 
 extension VimeoRequestSerializer
 {
+    private struct Constants
+    {
+        static let PreUploadKey = "_pre_upload"
+        static let PreUploadDefaultValue = true
+    }
+    
     func createVideoRequest(with url: URL, videoSettings: VideoSettings?) throws -> NSMutableURLRequest
     {
         var parameters = try self.createVideoRequestBaseParameters(url: url)
-        parameters["_pre_upload"] = true
+        parameters[Constants.PreUploadKey] = Constants.PreUploadDefaultValue
         
         if let videoSettings = videoSettings
         {

--- a/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
+++ b/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
@@ -1,5 +1,5 @@
 //
-//  VimeoRequestSerializer+SimpleUpload.swift
+//  VimeoRequestSerializer+Upload.swift
 //  VimeoUpload
 //
 //  Created by Alfred Hanssen on 11/20/15.
@@ -32,7 +32,7 @@ extension VimeoRequestSerializer
     func createVideoRequest(with url: URL, videoSettings: VideoSettings?) throws -> NSMutableURLRequest
     {
         var parameters = try self.createVideoRequestBaseParameters(url: url)
-        parameters["create_clip"] = "true"
+        parameters["_pre_upload"] = true
         
         if let videoSettings = videoSettings
         {

--- a/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
+++ b/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
@@ -59,9 +59,12 @@ extension VimeoRequestSerializer
         return request
     }
 
+    //old upload
     func createVideoRequest(with url: URL) throws -> NSMutableURLRequest
     {
-        let parameters = try self.createVideoRequestBaseParameters(url: url)
+        var parameters = try self.createFileSizeParameters(url: url)
+        
+        parameters["type"] = "streaming"
         
         let url = URL(string: "/me/videos", relativeTo: VimeoBaseURL)!
 
@@ -98,6 +101,25 @@ extension VimeoRequestSerializer
         let fileSizeString = String(fileSize)
         
         return [Constants.UploadKey: [Constants.ApproachKey: Constants.Approach.Streaming, Constants.SizeKey: fileSizeString]]
+    }
+    
+    func createFileSizeParameters(url: URL) throws -> [String: Any]
+    {
+        let asset = AVURLAsset(url: url)
+        
+        let fileSize: Double
+        do
+        {
+            fileSize = try asset.fileSize()
+        }
+        catch let error as NSError
+        {
+            throw error.error(byAddingDomain: UploadErrorDomain.Create.rawValue)
+        }
+        
+        let fileSizeString = fileSize
+        
+        return [Constants.SizeKey: fileSizeString]
     }
 
     func uploadVideoRequest(with source: URL, destination: String) throws -> NSMutableURLRequest

--- a/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
+++ b/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
@@ -30,7 +30,7 @@ import VimeoNetworking
 
 extension VimeoRequestSerializer
 {
-    struct Constants
+    private struct Constants
     {
         static let UploadKey = "upload"
         static let ApproachKey = "approach"

--- a/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
+++ b/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
@@ -29,20 +29,13 @@ import AVFoundation
 import VimeoNetworking
 
 extension VimeoRequestSerializer
-{
+{    
     private struct Constants
     {
-        static let UploadKey = "upload"
-        static let ApproachKey = "approach"
+        static let CreateVideoURI = "/me/videos"
+        static let TypeKey = "type"
+        static let TypeDefaultValue = "streaming"
         static let SizeKey = "size"
-        
-        struct Approach
-        {
-            static let Streaming = "streaming"
-            static let Post = "post"
-            static let Pull = "pull"
-            static let TUS = "tus"
-        }
     }
     
     func myVideosRequest() throws -> NSMutableURLRequest
@@ -58,15 +51,14 @@ extension VimeoRequestSerializer
         
         return request
     }
-
-    //old upload
+    
     func createVideoRequest(with url: URL) throws -> NSMutableURLRequest
     {
         var parameters = try self.createFileSizeParameters(url: url)
         
-        parameters["type"] = "streaming"
+        parameters[Constants.TypeKey] = Constants.TypeDefaultValue
         
-        let url = URL(string: "/me/videos", relativeTo: VimeoBaseURL)!
+        let url = URL(string: Constants.CreateVideoURI, relativeTo: VimeoBaseURL)!
 
         return try self.createVideoRequest(with: url, parameters: parameters)
     }
@@ -82,25 +74,6 @@ extension VimeoRequestSerializer
         }
         
         return request
-    }
-
-    func createVideoRequestBaseParameters(url: URL) throws -> [String: Any]
-    {
-        let asset = AVURLAsset(url: url)
-        
-        let fileSize: Double
-        do
-        {
-            fileSize = try asset.fileSize()
-        }
-        catch let error as NSError
-        {
-            throw error.error(byAddingDomain: UploadErrorDomain.Create.rawValue)
-        }
-        
-        let fileSizeString = String(fileSize)
-        
-        return [Constants.UploadKey: [Constants.ApproachKey: Constants.Approach.Streaming, Constants.SizeKey: fileSizeString]]
     }
     
     func createFileSizeParameters(url: URL) throws -> [String: Any]

--- a/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
+++ b/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
@@ -1,5 +1,5 @@
 //
-//  VimeoRequestSerializer+Upload.swift
+//  VimeoRequestSerializer+SharedUpload.swift
 //  VimeoUpload
 //
 //  Created by Alfred Hanssen on 10/21/15.
@@ -30,6 +30,21 @@ import VimeoNetworking
 
 extension VimeoRequestSerializer
 {
+    struct Constants
+    {
+        static let UploadKey = "upload"
+        static let ApproachKey = "approach"
+        static let SizeKey = "size"
+        
+        struct Approach
+        {
+            static let Streaming = "streaming"
+            static let Post = "post"
+            static let Pull = "pull"
+            static let TUS = "tus"
+        }
+    }
+    
     func myVideosRequest() throws -> NSMutableURLRequest
     {
         let url = URL(string: "/me/videos", relativeTo: VimeoBaseURL)!
@@ -80,7 +95,9 @@ extension VimeoRequestSerializer
             throw error.error(byAddingDomain: UploadErrorDomain.Create.rawValue)
         }
         
-        return ["type": "streaming", "size": fileSize]
+        let fileSizeString = String(fileSize)
+        
+        return [Constants.UploadKey: [Constants.ApproachKey: Constants.Approach.Streaming, Constants.SizeKey: fileSizeString]]
     }
 
     func uploadVideoRequest(with source: URL, destination: String) throws -> NSMutableURLRequest


### PR DESCRIPTION
#### Ticket

[VIM-6144](https://vimean.atlassian.net/browse/VIM-6144)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- To be compatible with API v3.4 and still have videos that are recognized as being in the uploading state (i.e. invisible to search results), we needed to explicitly say we are doing a pre upload by adding a parameter. (See ticket). 
- API issue linked for context https://github.vimeows.com/Vimeo-API/api/issues/2005

#### Implementation Summary

- Renamed file from old upload to shared upload given both new and old upload use API from this file
- Added parameters as per ticket specifications 
- Broke out literals into constants  

#### How to Test

- N/A this can only be tested once other upload changes are in place. I verified that we are able to receive videos in the pre upload privacy state to test that this works with other changes. Will have other PR include that test. 