### PR TITLE
VIM-XXX: Unarchive videos

### DIFF
--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -192,7 +192,7 @@ public class UploadDescriptor: ProgressDescriptor, VideoDescriptor
         {
             self.video = uploadTicket.video
         }
-        // Otherwise, support unarchived videos for API versions greater than v3.4
+        // Otherwise, support unarchived videos for API version v3.4
         else if let video = aDecoder.decodeObject(forKey: type(of: self).VideoCoderKey) as? VIMVideo
         {
             self.video = video

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -187,12 +187,17 @@ public class UploadDescriptor: ProgressDescriptor, VideoDescriptor
         
         self.url = URL(fileURLWithPath: path)
 
-        // Support migrating archived uploadTickets to videos for API versions less than v3.4
+        // Support migrating unarchived uploadTickets to videos for API versions less than v3.4
         if let uploadTicket = aDecoder.decodeObject(forKey: type(of: self).UploadTicketCoderKey) as? VIMUploadTicket
         {
             self.video = uploadTicket.video
         }
-
+        // Otherwise, support unarchived videos for API versions greater than v3.4
+        else if let video = aDecoder.decodeObject(forKey: type(of: self).VideoCoderKey) as? VIMVideo
+        {
+            self.video = video
+        }
+        
         super.init(coder: aDecoder)
     }
 


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

When upgrading the upload library to support API version 3.4, we handled the case where an upload descriptor was archived at an API version < 3.4 and unarchived at API version == 3.4

But we did not handle the case where both archiving and unarchiving are at API version 3.4. In this case, we archive a video, not an upload ticket, so we need to unarchive the video as is. 

Otherwise `descriptor.video` is nil post unarchiving.   

#### Implementation Summary

- Unarchive the archived `video` object. 

#### How to Test

- Force quit the app while uploading a video.
- Set a break point in `required public init(coder aDecoder: NSCoder)` of `UploadDescriptor`
- Rerun the app, and confirm that a video is unarchived inside of the else clause. 
