### PR TITLE
VIM-XXXX: Replace use of '+' with string interpolation

### DIFF
--- a/VimeoUpload/UIKit/Extensions/NSString+Conversions.swift
+++ b/VimeoUpload/UIKit/Extensions/NSString+Conversions.swift
@@ -83,18 +83,18 @@ public extension NSString
         {
             if minutes > 0
             {
-                result = minutes < 10 ? "0\(minutes)" + ":\(result)" : "\(minutes)" + ":\(result)"
+                result = minutes < 10 ? "0\(minutes):\(result)" : "\(minutes):\(result)"
             }
             else
             {
                 result = "00:\(result)"
             }
             
-            result = "\(hours)" + ":\(result)"
+            result = "\(hours):\(result)"
         }
         else
         {
-            result = "\(minutes)" + ":\(result)"
+            result = "\(minutes):\(result)"
         }
         
         return result as NSString


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Ticket Summary

- Using `+` with string literals has poor type-checking performance, see [here](https://github.vimeows.com/MobileApps/Style-Guides/pull/34).

#### Implementation Summary

- Wherever we had `+` used with string literals, use string interpolation instead.

#### Reviewer Tips

- Make sure interpolation replacements preserve semantics!

#### How to Test