### PR TITLE
VIM-6403: Remove `shouldLoadArchive` Arguments

### DIFF
--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -79,13 +79,11 @@ open class DescriptorManager: NSObject
     init?(sessionManager: AFURLSessionManager,
           name: String,
           archivePrefix: String?,
-          shouldLoadArchive: Bool,
           documentsFolderURL: URL,
           delegate: DescriptorManagerDelegate? = nil)
     {
         guard let archiver = DescriptorManagerArchiver(name: name,
                                                        archivePrefix: archivePrefix,
-                                                       shouldLoadArchive: shouldLoadArchive,
                                                        documentsFolderURL: documentsFolderURL)
         else
         {

--- a/VimeoUpload/Descriptor System/DescriptorManagerArchiver.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManagerArchiver.swift
@@ -44,14 +44,11 @@ class DescriptorManagerArchiver
             self.saveSuspendedState()
         }
     }
-    
-    private let shouldLoadArchive: Bool
 
     // MARK: - Initialization
     
     init?(name: String,
           archivePrefix: String?,
-          shouldLoadArchive: Bool = true,
           documentsFolderURL: URL)
     {
         guard let archiver = type(of: self).setupArchiver(name: name, archivePrefix: archivePrefix, documentsFolderURL: documentsFolderURL) else
@@ -60,8 +57,6 @@ class DescriptorManagerArchiver
         }
         
         self.archiver = archiver
-
-        self.shouldLoadArchive = shouldLoadArchive
         
         let migrator = ArchiveMigrator(fileManager: FileManager.default)
         
@@ -93,11 +88,6 @@ class DescriptorManagerArchiver
     
     private func loadDescriptors(withMigrator migrator: ArchiveMigrating?, relativeFolderURL: URL?) -> Set<Descriptor>
     {
-        guard self.shouldLoadArchive == true else
-        {
-            return Set<Descriptor>()
-        }
-        
         guard let descriptors = ArchiveDataLoader.loadData(relativeFolderURL: relativeFolderURL,
                                                         archiver: self.archiver,
                                                         key: DescriptorManagerArchiver.DescriptorsArchiveKey) as? Set<Descriptor>
@@ -116,11 +106,6 @@ class DescriptorManagerArchiver
     
     private func loadSuspendedState(withMigrator migrator: ArchiveMigrating?, relativeFolderURL: URL?) -> Bool
     {
-        guard self.shouldLoadArchive == true else
-        {
-            return false
-        }
-        
         guard let suspendedState = ArchiveDataLoader.loadData(relativeFolderURL: relativeFolderURL,
                                                               archiver: self.archiver,
                                                               key: DescriptorManagerArchiver.SuspendedArchiveKey) as? Bool

--- a/VimeoUpload/Descriptor System/ReachableDescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/ReachableDescriptorManager.swift
@@ -54,10 +54,6 @@ import VimeoNetworking
     ///   - archivePrefix: The prefix of the archive file. You pass in the
     ///   prefix if you want to keep track of multiple archive files. By
     ///   default, it has the value of `nil`.
-    ///   - shouldLoadArchive: A Boolean value that determines if the
-    ///   descriptor manager should load descriptors from the archive file
-    ///   upon instantiating. By default, this argument has the value of
-    ///   `true`.
     ///   - documentsFolderURL: The Documents folder's URL of the folder in
     ///   which the upload description will be stored. That folder has the
     ///   same name as the first argument.
@@ -74,7 +70,6 @@ import VimeoNetworking
     /// - Returns: `nil` if the keyed archiver cannot load descriptors' archive.
     public init?(name: String,
                  archivePrefix: String? = nil,
-                 shouldLoadArchive: Bool = true,
                  documentsFolderURL: URL,
                  backgroundSessionIdentifier: String,
                  sharedContainerIdentifier: String? = nil,
@@ -96,7 +91,6 @@ import VimeoNetworking
         super.init(sessionManager: backgroundSessionManager,
                    name: name,
                    archivePrefix: archivePrefix,
-                   shouldLoadArchive: shouldLoadArchive,
                    documentsFolderURL: documentsFolderURL,
                    delegate: descriptorManagerDelegate)
         

--- a/VimeoUpload/Upload/Controllers/VideoDeletionManager.swift
+++ b/VimeoUpload/Upload/Controllers/VideoDeletionManager.swift
@@ -43,7 +43,6 @@ public class VideoDeletionManager: NSObject
     private var deletions: [VideoUri: Int] = [:]
     private let operationQueue: OperationQueue
     private let archiver: KeyedArchiver
-    private let shouldLoadArchive: Bool
     
     // MARK: - Initialization
     
@@ -70,17 +69,12 @@ public class VideoDeletionManager: NSObject
     ///   - archivePrefix: The prefix of the archive file. You pass in the
     ///   prefix if you want to keep track of multiple archive files. By
     ///   default, it has the value of `nil`.
-    ///   - shouldLoadArchive: A Boolean value that determines if the
-    ///   descriptor manager should load descriptors from the archive file
-    ///   upon instantiating. By default, this argument has the value of
-    ///   `true`.
     ///   - documentsFolderURL: The Documents folder's URL in which the folder
     /// is located.
     ///   - retryCount: The number of retries. The default value is `3`.
     /// - Returns: `nil` if the keyed archiver cannot load deletions' archive.
     public init?(sessionManager: VimeoSessionManager,
                  archivePrefix: String? = nil,
-                 shouldLoadArchive: Bool = true,
                  documentsFolderURL: URL,
                  retryCount: Int = VideoDeletionManager.DefaultRetryCount)
     {
@@ -93,7 +87,6 @@ public class VideoDeletionManager: NSObject
         
         self.sessionManager = sessionManager
         self.retryCount = retryCount
-        self.shouldLoadArchive = shouldLoadArchive
      
         self.operationQueue = OperationQueue()
         self.operationQueue.maxConcurrentOperationCount = OperationQueue.defaultMaxConcurrentOperationCount
@@ -134,11 +127,6 @@ public class VideoDeletionManager: NSObject
     
     private func loadDeletions(withMigrator migrator: ArchiveMigrating?) -> [VideoUri: Int]
     {
-        guard self.shouldLoadArchive == true else
-        {
-            return [:]
-        }
-        
         let relativeFolderURL = URL(string: VideoDeletionManager.DeletionsArchiveKey)?.appendingPathComponent(VideoDeletionManager.DeletionsArchiveKey)
         guard let retries = ArchiveDataLoader.loadData(relativeFolderURL: relativeFolderURL,
                                                        archiver: self.archiver,

--- a/VimeoUpload/Upload/Descriptor System/VideoDescriptorFailureTracker.swift
+++ b/VimeoUpload/Upload/Descriptor System/VideoDescriptorFailureTracker.swift
@@ -34,7 +34,6 @@ import Foundation
     
     private let archiver: KeyedArchiver
     private var failedDescriptors: [String: Descriptor] = [:]
-    private let shouldLoadArchive: Bool
 
     // MARK: - Initialization
     
@@ -59,16 +58,11 @@ import Foundation
     ///   - archivePrefix: The prefix of the archive file. You pass in the
     ///   prefix if you want to keep track of multiple archive files. By
     ///   default, it has the value of `nil`.
-    ///   - shouldLoadArchive: A Boolean value that determines if the
-    ///   descriptor manager should load descriptors from the archive file
-    ///   upon instantiating. By default, this argument has the value of
-    ///   `true`.
     ///   - documentsFolderURL: The Documents folder's URL in which the folder
     ///   is located.
     /// - Returns: `nil` if the keyed archiver cannot load descriptors' archive.
     public init?(name: String,
                  archivePrefix: String? = nil,
-                 shouldLoadArchive: Bool = true,
                  documentsFolderURL: URL)
     {
         guard let archiver = type(of: self).setupArchiver(folderName: name, archivePrefix: archivePrefix, documentsFolderURL: documentsFolderURL) else
@@ -78,8 +72,6 @@ import Foundation
         
         self.archiver = archiver
         
-        self.shouldLoadArchive = shouldLoadArchive
-
         super.init()
         
         let migrator = ArchiveMigrator(fileManager: FileManager.default)
@@ -113,11 +105,6 @@ import Foundation
     
     private func load(relativeFolderURL: URL?, migrator: ArchiveMigrating?) -> [String: Descriptor]
     {
-        guard self.shouldLoadArchive == true else
-        {
-            return [:]
-        }
-        
         guard let failedDescriptors = ArchiveDataLoader.loadData(relativeFolderURL: relativeFolderURL,
                                                                  archiver: self.archiver,
                                                                  key: VideoDescriptorFailureTracker.ArchiveKey) as? [String: Descriptor]


### PR DESCRIPTION
#### Ticket

[VIM-6403](https://vimean.atlassian.net/browse/VIM-6403)

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

As the share extension's background session needs to be a singleton in order to work properly, there is no need for those `shouldLoadArchive` arguments anymore. We should remove them.

#### Implementation Summary

N/A

#### Reviewer Tips

N/A

#### How to Test

N/A
