### PR TITLE
VIM-6449: Add Generic Invalidation Error

### DIFF
--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -46,6 +46,13 @@ open class DescriptorManager: NSObject
         static let QueueName = "descriptor_manager.synchronization_queue"
         static let ShareExtensionArchivePrefix = "share_extension"
         static let ShareExtensionDescriptorDidSuspend = "ShareExtensionDescriptorDidSuspend"
+        
+        struct InvalidationError
+        {
+            static let Domain = "BackgroundSessionInvalidationError"
+            static let Code = 1
+            static let LocalizedDescription = "A session object referring to the same background session has been invalidated and thus disconnected from the session."
+        }
     }
     
     // MARK:
@@ -198,7 +205,8 @@ open class DescriptorManager: NSObject
                 let theError: NSError?
                 if error != nil
                 {
-                    theError = error as NSError
+                    let userInfo = [NSLocalizedDescriptionKey: Constants.InvalidationError.LocalizedDescription]
+                    theError = NSError(domain: Constants.InvalidationError.Domain, code: Constants.InvalidationError.Code, userInfo: userInfo)
                 }
                 else
                 {


### PR DESCRIPTION
#### Ticket

[VIM-6449](https://vimean.atlassian.net/browse/VIM-6449)

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR introduces a generic invalidation error. We will send this error along with the invalidation notification instead of using the error object returned to us by `AFNetworking`.

#### Implementation Summary

If you look at the crash log from HockeyApp and the stack trace from the Xcode's Organizer window, you'll see that there was something wrong with `release` calls inside the Swift's standard library when we tried to cast `Error` to `NSError`, at line 201 of `DescriptorManager`. To understand why this casting occurred from the beginning, let's recall how background session's handoff process works.

When a long upload is performed from the share extension, and the regular app is opened right after, the OS does not kill the share extension's process right away. Let's assume that the regular app is in foreground, and the upload completes before the share extension's process is terminated. When that occurs, the app will re-establish the connection with the background session, causing the session object existing in the share extension's process (which is a singleton) to be disconnected from it. Since the active session object gets the invalidation delegate call, it is the app that receives the call with an error object attached to it. 

That explains why the app crashed when a share extension's upload completed. This crash only occurs on a real device and with Xcode not running. If Xcode attaches to one of the running processes, the suspension/termination behavior can be altered, thus you won't be able to observe it.

This disconnection behavior is correct, so we should not avoid it; however, we still need to address the casting because internally the Swift's standard library cannot release data properly. My solution, then, is to not cast `Error` to `NSError` anymore, and instead to send our own custom error object.

#### Reviewer Tips

You should deploy the code onto your device, and test without running Xcode.

#### How to Test

1. Perform a long upload from the share extension (300 - 500 MB is sufficient.)
2. Right after tapping "Upload", quickly open the regular app.
3. Wait for the background upload to finish. To check the status of the upload, go to the Vimeo website, and open your video. If the status changes to "Upload X%", then it means the upload has finished.
4. Observe that the regular app does not crash anymore.