### PR TITLE
VIM-6542: Handle connectivity loss

### DIFF
--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -317,6 +317,9 @@ open class DescriptorManager: NSObject
                             try descriptor.prepare(sessionManager: strongSelf.sessionManager)
 
                             descriptor.resume(sessionManager: strongSelf.sessionManager) // TODO: for a specific number of retries? [AH]
+                            
+                            strongSelf.delegate?.descriptorDidResume?(descriptor)
+                            
                             strongSelf.save()
                         }
                         catch
@@ -598,6 +601,8 @@ open class DescriptorManager: NSObject
             for descriptor in strongSelf.archiver.descriptors
             {
                 descriptor.resume(sessionManager: strongSelf.sessionManager)
+                
+                strongSelf.delegate?.descriptorDidResume?(descriptor)
             }
             
             // Doing this after the loop rather than within, incrementally greater margin for error but faster

--- a/VimeoUpload/Descriptor System/DescriptorManagerDelegate.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManagerDelegate.swift
@@ -45,6 +45,8 @@ import Foundation
     @objc optional func descriptorDidSucceed(_ descriptor: Descriptor)
     @objc optional func descriptorDidCancel(_ descriptor: Descriptor)
     @objc optional func descriptorDidFail(_ descriptor: Descriptor)
-    
+
+    @objc optional func descriptorDidResume(_ descriptor: Descriptor)
+
     @objc optional func descriptorForTaskNotFound(_ task: URLSessionTask)
 }

--- a/VimeoUpload/Upload/Descriptor System/DescriptorManagerTracker.swift
+++ b/VimeoUpload/Upload/Descriptor System/DescriptorManagerTracker.swift
@@ -134,6 +134,14 @@ open class DescriptorManagerTracker: DescriptorManagerDelegate
     {
         self.printMessageAndPostLocalNotification("Descriptor for task not found")
     }
+
+    @objc open func descriptorDidResume(_ descriptor: Descriptor)
+    {
+        if let descriptorIdentifier = descriptor.identifier
+        {
+            self.printMessageAndPostLocalNotification("Resume \(descriptorIdentifier)")
+        }
+    }
     
     // Private API
     


### PR DESCRIPTION
#### Ticket

[VIM-6542](https://vimean.atlassian.net/browse/VIM-6542)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Ticket Summary

- Adds support for loss of connectivity during Fresnel tracking, which requires that the upload be cancelled and restarted when network connectivity comes back

#### Implementation Summary

- Adds delegate method for tracking resume after loss of connectivity 

#### How to Test

- See client PR