### PR TITLE
VIM-6667: Correct Data Type of File's Size

### DIFF
--- a/VimeoUpload/Upload/Extensions/AVAsset+Extensions.swift
+++ b/VimeoUpload/Upload/Extensions/AVAsset+Extensions.swift
@@ -29,18 +29,18 @@ import AVFoundation
 
 public extension AVAsset
 {    
-    func approximateFileSize(completion completion: @escaping FloatBlock)
+    func approximateFileSize(completion: @escaping DoubleBlock)
     {
         DispatchQueue.global(qos: .default).async { () -> Void in
-            var approximateSize: Float64 = 0
+            var approximateSize: Double = 0
             
             let tracks = self.tracks // Accessing the tracks property is slow, maybe synchronous below the hood, so dispatching to bg thread
             for track in tracks
             {
                 let dataRate: Float = track.estimatedDataRate
-                let bytesPerSecond = dataRate / Float(8)
-                let seconds: Float64 = CMTimeGetSeconds(track.timeRange.duration)
-                approximateSize += seconds * Float64(bytesPerSecond)
+                let bytesPerSecond = Double(dataRate / 8)
+                let seconds: Double = CMTimeGetSeconds(track.timeRange.duration)
+                approximateSize += seconds * bytesPerSecond
             }
             
             assert(approximateSize > 0, "Unable to calculate approximate fileSize")

--- a/VimeoUpload/Upload/Model/BlockTypes.swift
+++ b/VimeoUpload/Upload/Model/BlockTypes.swift
@@ -30,7 +30,7 @@ import VimeoNetworking
 public typealias ProgressBlock = (Double) -> Void
 public typealias ErrorBlock = (NSError?) -> Void
 public typealias StringErrorBlock = (String?, NSError?) -> Void
-public typealias FloatBlock = (Float64) -> Void
+public typealias DoubleBlock = (Double) -> Void
 
 public typealias UserCompletionHandler = (VIMUser?, NSError?) -> Void
 public typealias VideoCompletionHandler = (VIMVideo?, NSError?) -> Void


### PR DESCRIPTION
#### Ticket

[VIM-6667](https://vimean.atlassian.net/browse/VIM-6667)

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR converts the file's size's computation from `Float64` to `Double`.

#### Implementation Summary

N/A

#### Reviewer Tips

N/A

#### How to Test

N/A
