### PR TITLE
VIM-6707: Handle GCS Response

### DIFF
--- a/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
+++ b/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		8E8F1F7D20CF05C40048E8BB /* ArchiveMigrating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8F1F7C20CF05C40048E8BB /* ArchiveMigrating.swift */; };
 		8E8F1FC720EE9E2A0048E8BB /* ArchiveMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8F1FC620EE9E2A0048E8BB /* ArchiveMigrator.swift */; };
 		8EB2E478219B7ADD0083C2AA /* UploadStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB2E477219B7ADD0083C2AA /* UploadStrategy.swift */; };
+		8EB352A721BAEC6E00B108C3 /* Retriable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB352A621BAEC6E00B108C3 /* Retriable.swift */; };
 		AF40D4E51CCE9CB600753ABA /* VimeoUpload.h in Headers */ = {isa = PBXBuildFile; fileRef = AF40D4E41CCE9CB600753ABA /* VimeoUpload.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AF40D4EC1CCE9CB600753ABA /* VimeoUpload.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF40D4E11CCE9CB600753ABA /* VimeoUpload.framework */; };
 		AF40D4F11CCE9CB600753ABA /* VimeoUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF40D4F01CCE9CB600753ABA /* VimeoUploadTests.swift */; };
@@ -93,6 +94,7 @@
 		8E8F1F7C20CF05C40048E8BB /* ArchiveMigrating.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchiveMigrating.swift; sourceTree = "<group>"; };
 		8E8F1FC620EE9E2A0048E8BB /* ArchiveMigrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchiveMigrator.swift; sourceTree = "<group>"; };
 		8EB2E477219B7ADD0083C2AA /* UploadStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadStrategy.swift; sourceTree = "<group>"; };
+		8EB352A621BAEC6E00B108C3 /* Retriable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Retriable.swift; sourceTree = "<group>"; };
 		AF40D4E11CCE9CB600753ABA /* VimeoUpload.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VimeoUpload.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF40D4E41CCE9CB600753ABA /* VimeoUpload.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VimeoUpload.h; sourceTree = "<group>"; };
 		AF40D4E61CCE9CB600753ABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -368,6 +370,7 @@
 				AF40D5251CCE9DEB00753ABA /* AVURLAsset+Extensions.swift */,
 				AF40D5261CCE9DEB00753ABA /* NSError+Upload.swift */,
 				AF40D5271CCE9DEB00753ABA /* NSURL+Upload.swift */,
+				8EB352A621BAEC6E00B108C3 /* Retriable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -625,6 +628,7 @@
 				AF40D55A1CCE9DEB00753ABA /* AFURLSessionManager+Extensions.swift in Sources */,
 				3EA2DAD81DFF3E0F006E2C65 /* ExportSessionOperation.swift in Sources */,
 				AF40D5791CCE9DEB00753ABA /* ConcurrentOperation.swift in Sources */,
+				8EB352A721BAEC6E00B108C3 /* Retriable.swift in Sources */,
 				AF40D5781CCE9DEB00753ABA /* VimeoSessionManager+OldUpload.swift in Sources */,
 				AF40D5721CCE9DEB00753ABA /* BlockTypes.swift in Sources */,
 				3C53EC281D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift in Sources */,

--- a/VimeoUpload/Descriptor System/Descriptor.swift
+++ b/VimeoUpload/Descriptor System/Descriptor.swift
@@ -163,4 +163,11 @@ open class Descriptor: NSObject, NSCoding, Retriable
             aCoder.encode(currentTaskIdentifier, forKey: type(of: self).CurrentTaskIdentifierCoderKey)
         }
     }
+    
+    // MARK: - Retriable
+    
+    public func shouldRetry(urlResponse: URLResponse?) -> Bool
+    {
+        return false
+    }
 }

--- a/VimeoUpload/Descriptor System/Descriptor.swift
+++ b/VimeoUpload/Descriptor System/Descriptor.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Vimeo. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Softwarepublic public "), to deal
+//  of this software and associated documentation files (the "Software"), to deal
 //  in the Software without restriction, including without limitation the rights
 //  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 //  copies of the Software, and to permit persons to whom the Software is

--- a/VimeoUpload/Descriptor System/Descriptor.swift
+++ b/VimeoUpload/Descriptor System/Descriptor.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Vimeo. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
+//  of this software and associated documentation files (the "Softwarepublic public "), to deal
 //  in the Software without restriction, including without limitation the rights
 //  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 //  copies of the Software, and to permit persons to whom the Software is
@@ -35,7 +35,7 @@ public enum DescriptorState: String
     case finished = "Finished"
 }
 
-open class Descriptor: NSObject, NSCoding
+open class Descriptor: NSObject, NSCoding, Retriable
 {
     private static let StateCoderKey = "state"
     private static let IdentifierCoderKey = "identifier"

--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -361,7 +361,7 @@ open class DescriptorManager: NSObject
                     }
                     else if descriptor.shouldRetry(urlResponse: task.response)
                     {
-                        
+                        strongSelf.retry(descriptor)
                     }
                     else
                     {

--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -338,6 +338,13 @@ open class DescriptorManager: NSObject
                     return
                 }
                 
+                if descriptor.shouldRetry(urlResponse: task.response)
+                {
+                    strongSelf.retry(descriptor)
+                    
+                    return
+                }
+                
                 strongSelf.delegate?.taskDidComplete?(task: task, descriptor: descriptor, error: error as NSError?)
                 descriptor.taskDidComplete(sessionManager: strongSelf.sessionManager, task: task, error: error as NSError?)
                 
@@ -358,10 +365,6 @@ open class DescriptorManager: NSObject
                         
                         strongSelf.delegate?.descriptorDidFail?(descriptor)
                         NotificationCenter.default.post(name: Notification.Name(rawValue: DescriptorManagerNotification.DescriptorDidFail.rawValue), object: descriptor)
-                    }
-                    else if descriptor.shouldRetry(urlResponse: task.response)
-                    {
-                        strongSelf.retry(descriptor)
                     }
                     else
                     {

--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -339,7 +339,7 @@ open class DescriptorManager: NSObject
                     return
                 }
                 
-                if descriptor.shouldRetry(urlResponse: task.response)
+                guard descriptor.shouldRetry(urlResponse: task.response) == false else
                 {
                     strongSelf.retry(descriptor)
                     

--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -321,7 +321,8 @@ open class DescriptorManager: NSObject
                 // attempt to retry for a week before returning with a connection error.
                 // [VN] (07/03/2018)
                 let isConnectionError = ((task.error as? NSError)?.isConnectionError() == true || (error as? NSError)?.isConnectionError() == true)
-                if isConnectionError
+                
+                guard isConnectionError == false else
                 {
                     if let prefix = strongSelf.archivePrefix, prefix == Constants.ShareExtensionArchivePrefix
                     {

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -220,7 +220,7 @@ open class UploadDescriptor: ProgressDescriptor, VideoDescriptor
     
     // MARK: - Retriable
     
-    func shouldRetry(urlResponse: URLResponse?) -> Bool
+    override public func shouldRetry(urlResponse: URLResponse?) -> Bool
     {
         return self.uploadStrategy.shouldRetry(urlResponse: urlResponse)
     }

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -217,4 +217,11 @@ open class UploadDescriptor: ProgressDescriptor, VideoDescriptor
         
         super.encode(with: aCoder)
     }
+    
+    // MARK: - Retriable
+    
+    func shouldRetry(urlResponse: URLResponse?) -> Bool
+    {
+        return self.uploadStrategy.shouldRetry(urlResponse: urlResponse)
+    }
 }

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadStrategy.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadStrategy.swift
@@ -62,6 +62,10 @@ public protocol UploadStrategy
     /// with the upload link.
     static func uploadLink(from video: VIMVideo) throws -> String
     
+    /// Determines if an upload task should retry.
+    ///
+    /// - Parameter urlResponse: A HTTP server response.
+    /// - Returns: `true` if the task should retry; `false` otherwise.
     static func shouldRetry(urlResponse: URLResponse?) -> Bool
 }
 

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadStrategy.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadStrategy.swift
@@ -61,6 +61,8 @@ public protocol UploadStrategy
     /// - Throws: One of the values of `UploadLinkError` if there is a problem
     /// with the upload link.
     static func uploadLink(from video: VIMVideo) throws -> String
+    
+    static func shouldRetry(urlResponse: URLResponse?) -> Bool
 }
 
 /// An upload strategy that supports the streaming upload approach.
@@ -94,5 +96,10 @@ public struct StreamingUploadStrategy: UploadStrategy
         }
         
         return uploadLink
+    }
+    
+    public static func shouldRetry(urlResponse: URLResponse?) -> Bool
+    {
+        return false
     }
 }

--- a/VimeoUpload/Upload/Extensions/Retriable.swift
+++ b/VimeoUpload/Upload/Extensions/Retriable.swift
@@ -1,0 +1,22 @@
+//
+//  Retriable.swift
+//  VimeoUpload
+//
+//  Created by Nguyen, Van on 12/7/18.
+//  Copyright © 2018 Vimeo. All rights reserved.
+//
+
+import Foundation
+
+public protocol Retriable
+{
+    func shouldRetry(urlResponse: URLResponse?) -> Bool
+}
+
+public extension Retriable where Self: Descriptor
+{
+    func shouldRetry(urlResponse: URLResponse?) -> Bool
+    {
+        return true
+    }
+}

--- a/VimeoUpload/Upload/Extensions/Retriable.swift
+++ b/VimeoUpload/Upload/Extensions/Retriable.swift
@@ -38,11 +38,3 @@ public protocol Retriable
     /// otherwise.
     func shouldRetry(urlResponse: URLResponse?) -> Bool
 }
-
-public extension Retriable where Self: Descriptor
-{
-    func shouldRetry(urlResponse: URLResponse?) -> Bool
-    {
-        return false
-    }
-}

--- a/VimeoUpload/Upload/Extensions/Retriable.swift
+++ b/VimeoUpload/Upload/Extensions/Retriable.swift
@@ -17,6 +17,6 @@ public extension Retriable where Self: Descriptor
 {
     func shouldRetry(urlResponse: URLResponse?) -> Bool
     {
-        return true
+        return false
     }
 }

--- a/VimeoUpload/Upload/Extensions/Retriable.swift
+++ b/VimeoUpload/Upload/Extensions/Retriable.swift
@@ -8,8 +8,16 @@
 
 import Foundation
 
+/// Classes conforming to `Retriable` can determine if they should
+/// retry uploading/downloading based on the server response.
 public protocol Retriable
 {
+    /// Determines if an upload/download should retry based on an HTTP
+    /// response.
+    ///
+    /// - Parameter urlResponse: An HTTP response.
+    /// - Returns: `true` if an upload/download should retry, and `false`
+    /// otherwise.
     func shouldRetry(urlResponse: URLResponse?) -> Bool
 }
 

--- a/VimeoUpload/Upload/Extensions/Retriable.swift
+++ b/VimeoUpload/Upload/Extensions/Retriable.swift
@@ -5,6 +5,24 @@
 //  Created by Nguyen, Van on 12/7/18.
 //  Copyright © 2018 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 


### PR DESCRIPTION
#### Ticket

[VIM-6707](https://vimean.atlassian.net/browse/VIM-6707)

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR attempts to retry an GCS upload request whenever we encounter either a 404 or a 5xx status code.

#### Implementation Summary

See the client's PR for more detail.

- **`Retriable`**: Added the protocol to assist a descriptor in determining if it should retry.
- **`UploadDescriptor`**: Asked the upload strategy if it should retry.
- **`DescriptorManager`**: Retried a descriptor before checking for any error; also refactored the retry code into a separate function.

#### Reviewer Tips

N/A

#### How to Test

Run all unit tests. Check that they all pass.
