### PR TITLE
VIM-6601: Slight refactor of where upload parameters are set

### DIFF
--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -57,10 +57,7 @@ open class UploadDescriptor: ProgressDescriptor, VideoDescriptor
         return self
     }
     
-    open var uploadStrategy: UploadStrategy.Type
-    {
-        return StreamingUploadStrategy.self
-    }
+    open var uploadStrategy: UploadStrategy.Type = StreamingUploadStrategy.self
     
     // MARK: - Initialization
     

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadStrategy.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadStrategy.swift
@@ -43,6 +43,11 @@ public enum UploadLinkError: Error
 /// and an upload link.
 public protocol UploadStrategy
 {
+    /// Returns the appropriate upload request parameters for creating a video on Vimeo's server
+    ///
+    /// - Returns: A dictionary of upload parameters
+    static func createVideoUploadParameters() -> UploadParameters
+    
     /// Creates an upload request for the upload descriptor.
     ///
     /// - Parameters:
@@ -75,6 +80,11 @@ public struct StreamingUploadStrategy: UploadStrategy
     public enum ErrorCode: Error
     {
         case requestSerializerUnavailable
+    }
+    
+    public static func createVideoUploadParameters() -> UploadParameters
+    {
+        return [VimeoSessionManager.Constants.ApproachKey : VimeoSessionManager.Constants.StreamingApproachValue]
     }
     
     public static func uploadRequest(requestSerializer: VimeoRequestSerializer?, fileUrl: URL, uploadLink: String) throws -> URLRequest

--- a/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoSessionManager+Upload.swift
+++ b/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoSessionManager+Upload.swift
@@ -35,7 +35,7 @@ extension VimeoSessionManager
     {
         public static let ApproachKey = "approach"
         public static let StreamingApproachValue = VIMUpload.UploadApproach.Streaming.rawValue
-        public static let DefaultUploadParameters: UploadParameters = [ApproachKey : StreamingApproachValue]
+        public static let DefaultUploadParameters: UploadParameters = VimeoUploader<VideoDescriptor>.DefaultUploadStrategy.createVideoUploadParameters()
     }
     
     func createVideoDataTask(url: URL, videoSettings: VideoSettings?, uploadParameters: UploadParameters, completionHandler: @escaping VideoCompletionHandler) throws -> URLSessionDataTask

--- a/VimeoUpload/VimeoUploader.swift
+++ b/VimeoUpload/VimeoUploader.swift
@@ -34,6 +34,11 @@ open class VimeoUploader<T: VideoDescriptor>
         return "vimeo_upload" // Generic types don't yet support static properties [AH] 3/19/2016
     }
     
+    public static var DefaultUploadStrategy: UploadStrategy.Type
+    {
+        return StreamingUploadStrategy.self
+    }
+    
     // MARK:
     
     public let descriptorManager: ReachableDescriptorManager


### PR DESCRIPTION
#### Ticket

[VIM-6601](https://vimean.atlassian.net/browse/VIM-6601)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

Slight refactor of where upload parameters are set

#### Implementation Summary

- Makes upload strategy a stored property
- Moves upload parameters to be contained by the upload strategy 

#### How to Test

- Make sure unit tests pass