### PR TITLE
VIM-6785: Add max retries to GCS upload request

### DIFF
--- a/VimeoUpload/Descriptor System/Descriptor.swift
+++ b/VimeoUpload/Descriptor System/Descriptor.swift
@@ -60,7 +60,9 @@ open class Descriptor: NSObject, NSCoding, Retriable
     public var error: NSError?
     
     private(set) open var isCancelled = false
-    private(set) open var attemptNumber: Int = 0
+
+    // MARK: - Retriable conformance
+    private(set) open var retryAttemptCount: Int = 0
     
     // MARK: - Initialization
 
@@ -117,7 +119,7 @@ open class Descriptor: NSObject, NSCoding, Retriable
     }
 
     open func retry(sessionManager: AFURLSessionManager) throws {
-        self.attemptNumber += 1
+        self.retryAttemptCount += 1
         try self.prepare(sessionManager: sessionManager)
         self.resume(sessionManager: sessionManager)
     }
@@ -158,9 +160,6 @@ open class Descriptor: NSObject, NSCoding, Retriable
         self.identifier = aDecoder.decodeObject(forKey: type(of: self).IdentifierCoderKey) as? String
         self.error = aDecoder.decodeObject(forKey: type(of: self).ErrorCoderKey) as? NSError
         self.currentTaskIdentifier = aDecoder.decodeInteger(forKey: type(of: self).CurrentTaskIdentifierCoderKey)
-
-        // Because attempt number does not need to be robust, we don't bother persisting [FK 2/7/19]
-        self.attemptNumber = 0
     }
     
     open func encode(with aCoder: NSCoder)

--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -153,12 +153,8 @@ open class DescriptorManager: NSObject
     private func retry(_ descriptor: Descriptor) {
         do
         {
-            try descriptor.prepare(sessionManager: self.sessionManager)
-            
-            descriptor.resume(sessionManager: self.sessionManager) // TODO: for a specific number of retries? [AH]
-            
+            try descriptor.retry(sessionManager: self.sessionManager)
             self.delegate?.descriptorDidResume?(descriptor)
-            
             self.save()
         }
         catch

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -30,10 +30,14 @@ import AFNetworking
 
 open class UploadDescriptor: ProgressDescriptor, VideoDescriptor
 {
-    private static let FileNameCoderKey = "fileName"
-    private static let FileExtensionCoderKey = "fileExtension"
-    private static let UploadTicketCoderKey = "uploadTicket"
-    private static let VideoCoderKey = "video"
+    private struct Constants {
+        static let FileNameCoderKey = "fileName"
+        static let FileExtensionCoderKey = "fileExtension"
+        static let UploadTicketCoderKey = "uploadTicket"
+        static let VideoCoderKey = "video"
+
+        static let MaxAttempts = 10
+    }
 
     // MARK: 
     
@@ -184,20 +188,20 @@ open class UploadDescriptor: ProgressDescriptor, VideoDescriptor
     
     required public init(coder aDecoder: NSCoder)
     {
-        let fileName = aDecoder.decodeObject(forKey: type(of: self).FileNameCoderKey) as! String 
-        let fileExtension = aDecoder.decodeObject(forKey: type(of: self).FileExtensionCoderKey) as! String
+        let fileName = aDecoder.decodeObject(forKey: type(of: self).Constants.FileNameCoderKey) as! String
+        let fileExtension = aDecoder.decodeObject(forKey: type(of: self).Constants.FileExtensionCoderKey) as! String
         let path = URL.uploadDirectory().appendingPathComponent(fileName).appendingPathExtension(fileExtension).absoluteString
         
         self.url = URL(fileURLWithPath: path)
 
         // Support migrating archived uploadTickets to videos for API versions less than v3.4
-        if let uploadTicket = aDecoder.decodeObject(forKey: type(of: self).UploadTicketCoderKey) as? VIMUploadTicket
+        if let uploadTicket = aDecoder.decodeObject(forKey: type(of: self).Constants.UploadTicketCoderKey) as? VIMUploadTicket
         {
             self.video = uploadTicket.video
         }
         else
         {
-            self.video = aDecoder.decodeObject(forKey: type(of: self).VideoCoderKey) as? VIMVideo
+            self.video = aDecoder.decodeObject(forKey: type(of: self).Constants.VideoCoderKey) as? VIMVideo
         }
 
         super.init(coder: aDecoder)
@@ -208,9 +212,9 @@ open class UploadDescriptor: ProgressDescriptor, VideoDescriptor
         let fileName = self.url.deletingPathExtension().lastPathComponent
         let ext = self.url.pathExtension
 
-        aCoder.encode(fileName, forKey: type(of: self).FileNameCoderKey)
-        aCoder.encode(ext, forKey: type(of: self).FileExtensionCoderKey)
-        aCoder.encode(self.video, forKey: type(of: self).VideoCoderKey)
+        aCoder.encode(fileName, forKey: type(of: self).Constants.FileNameCoderKey)
+        aCoder.encode(ext, forKey: type(of: self).Constants.FileExtensionCoderKey)
+        aCoder.encode(self.video, forKey: type(of: self).Constants.VideoCoderKey)
         
         super.encode(with: aCoder)
     }
@@ -219,6 +223,6 @@ open class UploadDescriptor: ProgressDescriptor, VideoDescriptor
     
     override public func shouldRetry(urlResponse: URLResponse?) -> Bool
     {
-        return self.uploadStrategy.shouldRetry(urlResponse: urlResponse)
+        return self.uploadStrategy.shouldRetry(urlResponse: urlResponse) && self.attemptNumber < Constants.MaxAttempts - 1
     }
 }

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -223,6 +223,6 @@ open class UploadDescriptor: ProgressDescriptor, VideoDescriptor
     
     override public func shouldRetry(urlResponse: URLResponse?) -> Bool
     {
-        return self.uploadStrategy.shouldRetry(urlResponse: urlResponse) && self.attemptNumber < Constants.MaxAttempts - 1
+        return self.uploadStrategy.shouldRetry(urlResponse: urlResponse) && self.retryAttemptCount < Constants.MaxAttempts - 1
     }
 }

--- a/VimeoUpload/Upload/Extensions/Retriable.swift
+++ b/VimeoUpload/Upload/Extensions/Retriable.swift
@@ -41,5 +41,5 @@ public protocol Retriable
     /// This gives the (0-based) number of times that a retriable upload/download
     /// has been retried. On the first try, `attemptNumber` is 0, and incremented
     /// by 1 on each retry.
-    var attemptNumber: Int { get }
+    var retryAttemptCount: Int { get }
 }

--- a/VimeoUpload/Upload/Extensions/Retriable.swift
+++ b/VimeoUpload/Upload/Extensions/Retriable.swift
@@ -37,4 +37,9 @@ public protocol Retriable
     /// - Returns: `true` if an upload/download should retry, and `false`
     /// otherwise.
     func shouldRetry(urlResponse: URLResponse?) -> Bool
+
+    /// This gives the (0-based) number of times that a retriable upload/download
+    /// has been retried. On the first try, `attemptNumber` is 0, and incremented
+    /// by 1 on each retry.
+    var attemptNumber: Int { get }
 }


### PR DESCRIPTION
#### Ticket

[VIM-6785](https://vimean.atlassian.net/browse/VIM-6785)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- We want to limit the number of times that an upload will be retried to prevent an infinite loop where a corrupted/invalid request fails over and over.

#### Implementation Summary

**Retriable.swift**
- Add a new `attemptNumber` property that tracks how many times a `Retriable` object has been retried.

**Descriptor.swift**
- Add `attemptNumber` property required by `Retriable` protocol.
- Add new open `retry(sessionManager:)` method so that `Descriptor` can keep track of its own retries.
- When loading from a coder, just set `attemptNumber` to `0`, don't bother persisting to disk.

**DescriptorManager.swift**
- Use the new `retry(sessionManager:)` API in `Descriptor`

**UploadDescriptor.swift**
- Create new `Constants` struct and move coding keys into it.
- Add new `MaxAttempts` constant, set to 10 (this constant was chosen based on [this documentation from Google](https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload) but 10 is just an example there so this decision was relatively arbitrary).
- Modify `shouldRetry` to return `false` if the max number of attempts has been reached.


#### Reviewer Tips

#### How to Test

