### PR TITLE
VIM-6830: Add MIMEtype to video creation

### DIFF
--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS.xcodeproj/project.pbxproj
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3EA4C85A2094FE57009F3D9B /* NSKeyedUnarchiver+Migrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA4C8592094FE57009F3D9B /* NSKeyedUnarchiver+Migrations.swift */; };
+		3EA5DCC3220B735C00321273 /* URL+MIMETypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DCC2220B735C00321273 /* URL+MIMETypeTests.swift */; };
 		5009CCE91E00604200887FC1 /* VimeoUpload.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5009CCE81E00604200887FC1 /* VimeoUpload.framework */; };
 		5009CCEA1E00604200887FC1 /* VimeoUpload.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5009CCE81E00604200887FC1 /* VimeoUpload.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5073D6EB1CAD66C600D08C5F /* DemoCameraRollCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5073D6E61CAD66C600D08C5F /* DemoCameraRollCell.swift */; };
@@ -61,6 +62,7 @@
 
 /* Begin PBXFileReference section */
 		3EA4C8592094FE57009F3D9B /* NSKeyedUnarchiver+Migrations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSKeyedUnarchiver+Migrations.swift"; sourceTree = "<group>"; };
+		3EA5DCC2220B735C00321273 /* URL+MIMETypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+MIMETypeTests.swift"; sourceTree = "<group>"; };
 		47ED4955B1448D82B035D2BF /* Pods_VimeoUpload_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoUpload_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		49DF265822E7E25ECC46C743 /* Pods_VimeoUpload_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoUpload_iOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5009CCE81E00604200887FC1 /* VimeoUpload.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = VimeoUpload.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -204,6 +206,7 @@
 			isa = PBXGroup;
 			children = (
 				8EBE8EA7218263C60041553F /* wide_worlds.mp4 */,
+				3EA5DCC2220B735C00321273 /* URL+MIMETypeTests.swift */,
 				8E8246D721826056006EF68C /* VimeoRequestSerializerTests.swift */,
 				AFFA3F2E1C9CE22500C7B6F3 /* Info.plist */,
 				8EB2E46F219B227C0083C2AA /* StreamingUploadStrategyTests.swift */,
@@ -437,6 +440,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3EA5DCC3220B735C00321273 /* URL+MIMETypeTests.swift in Sources */,
 				8E8246D821826057006EF68C /* VimeoRequestSerializerTests.swift in Sources */,
 				8EB2E470219B227C0083C2AA /* StreamingUploadStrategyTests.swift in Sources */,
 			);

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOSTests/URL+MIMETypeTests.swift
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOSTests/URL+MIMETypeTests.swift
@@ -1,0 +1,28 @@
+//
+//  URL+MIMETypeTests.swift
+//  VimeoUpload-iOSTests
+//
+//  Created by Lehrer, Nicole on 2/6/19.
+//  Copyright © 2019 Alfie Hanssen. All rights reserved.
+//
+
+import XCTest
+
+class URL_MIMETypeTests: XCTestCase {
+
+    let urlMP4 = URL(string: "testFile.mp4")
+    let urlQuickTime = URL(string: "testFile.mov")
+    let urlAVI = URL(string: "testFile.avi")
+
+    func test_MIMEType_returnsVideoMP4() {
+        XCTAssertTrue(try urlMP4?.MIMEType() == "video/mp4")
+    }
+    
+    func test_MIMEType_returnsVideoQuicktime(){
+        XCTAssertTrue(try urlQuickTime?.MIMEType() == "video/quicktime")
+    }
+    
+    func test_MIMEType_returnsVideoAVI(){
+        XCTAssertTrue(try urlAVI?.MIMEType() == "video/avi")
+    }
+}

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOSTests/URL+MIMETypeTests.swift
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOSTests/URL+MIMETypeTests.swift
@@ -15,14 +15,14 @@ class URL_MIMETypeTests: XCTestCase {
     let urlAVI = URL(string: "testFile.avi")
 
     func test_MIMEType_returnsVideoMP4() {
-        XCTAssertTrue(try urlMP4?.MIMEType() == "video/mp4")
+        XCTAssertTrue(try urlMP4?.mimeType() == "video/mp4")
     }
     
     func test_MIMEType_returnsVideoQuicktime(){
-        XCTAssertTrue(try urlQuickTime?.MIMEType() == "video/quicktime")
+        XCTAssertTrue(try urlQuickTime?.mimeType() == "video/quicktime")
     }
     
     func test_MIMEType_returnsVideoAVI(){
-        XCTAssertTrue(try urlAVI?.MIMEType() == "video/avi")
+        XCTAssertTrue(try urlAVI?.mimeType() == "video/avi")
     }
 }

--- a/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
+++ b/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3C53EC281D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */; };
 		3EA2DAD81DFF3E0F006E2C65 /* ExportSessionOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA2DAD51DFF3E0F006E2C65 /* ExportSessionOperation.swift */; };
 		3EA4C84D209017FB009F3D9B /* VimeoRequestSerializer+SharedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA4C84C209017FB009F3D9B /* VimeoRequestSerializer+SharedUpload.swift */; };
+		3EBEF51B22095216000CB4E0 /* URL+MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBEF51A22095216000CB4E0 /* URL+MIMEType.swift */; };
 		5C9E3CA51EA66187000D1F6B /* DescriptorKVObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9E3CA41EA66187000D1F6B /* DescriptorKVObserver.swift */; };
 		8D9A15BCC5ABADC2D001B20C /* Pods_VimeoUpload.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D4E8D665288660F1F668B91 /* Pods_VimeoUpload.framework */; };
 		8E8F1F7D20CF05C40048E8BB /* ArchiveMigrating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8F1F7C20CF05C40048E8BB /* ArchiveMigrating.swift */; };
@@ -89,6 +90,7 @@
 		3C53EC231D219C8500B7AA6D /* VimeoSessionManager+ThumbnailUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VimeoSessionManager+ThumbnailUpload.swift"; path = "Cameo/VimeoSessionManager+ThumbnailUpload.swift"; sourceTree = "<group>"; };
 		3EA2DAD51DFF3E0F006E2C65 /* ExportSessionOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExportSessionOperation.swift; sourceTree = "<group>"; };
 		3EA4C84C209017FB009F3D9B /* VimeoRequestSerializer+SharedUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VimeoRequestSerializer+SharedUpload.swift"; sourceTree = "<group>"; };
+		3EBEF51A22095216000CB4E0 /* URL+MIMEType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+MIMEType.swift"; sourceTree = "<group>"; };
 		4D4E8D665288660F1F668B91 /* Pods_VimeoUpload.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoUpload.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C9E3CA41EA66187000D1F6B /* DescriptorKVObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescriptorKVObserver.swift; sourceTree = "<group>"; };
 		8E8F1F7C20CF05C40048E8BB /* ArchiveMigrating.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchiveMigrating.swift; sourceTree = "<group>"; };
@@ -274,6 +276,7 @@
 				AF40D5061CCE9DEB00753ABA /* AFURLSessionManager+Extensions.swift */,
 				AF40D5071CCE9DEB00753ABA /* NSError+Extensions.swift */,
 				AF40D5081CCE9DEB00753ABA /* NSFileManager+Extensions.swift */,
+				3EBEF51A22095216000CB4E0 /* URL+MIMEType.swift */,
 			);
 			name = Extensions;
 			path = ../../../VimeoUpload/Extensions;
@@ -605,6 +608,7 @@
 				AF40D5541CCE9DEB00753ABA /* DescriptorManager.swift in Sources */,
 				AF40D5521CCE9DEB00753ABA /* ConnectivityManager.swift in Sources */,
 				AF40D5751CCE9DEB00753ABA /* VimeoSessionManager+Upload.swift in Sources */,
+				3EBEF51B22095216000CB4E0 /* URL+MIMEType.swift in Sources */,
 				AF40D56E1CCE9DEB00753ABA /* AVAsset+Extensions.swift in Sources */,
 				AF40D5511CCE9DEB00753ABA /* ArchiverProtocol.swift in Sources */,
 				AF40D5561CCE9DEB00753ABA /* DescriptorManagerDelegate.swift in Sources */,

--- a/VimeoUpload/Extensions/URL+MIMEType.swift
+++ b/VimeoUpload/Extensions/URL+MIMEType.swift
@@ -9,9 +9,7 @@ import MobileCoreServices
 
 extension URL
 {
-    /// A helper for determining a file's MIMEType, adapted from:
-    /// - https://stackoverflow.com/questions/31243371/path-extension-and-mime-type-of-file-in-swift
-    /// - https://stackoverflow.com/questions/1363813/how-can-you-read-a-files-mime-type-in-objective-c
+    /// A helper for determining a file's MIMEType
     ///
     /// - Returns: MIMEType as String
     /// - Throws: throws an error if the MIMEType cannot be determined

--- a/VimeoUpload/Extensions/URL+MIMEType.swift
+++ b/VimeoUpload/Extensions/URL+MIMEType.swift
@@ -13,7 +13,7 @@ public extension URL
     ///
     /// - Returns: MIMEType as String
     /// - Throws: throws an error if the MIMEType cannot be determined
-    public func MIMEType() throws -> String {
+    public func mimeType() throws -> String {
         
         let userInfo = [NSLocalizedDescriptionKey: "No detectable MIMEType"]
         let error = NSError(domain: "URLExtension.VimeoUpload", code: 0, userInfo: userInfo)
@@ -28,15 +28,12 @@ public extension URL
             throw error
         }
         
-        let retainedUniformTypeID = uniformTypeID.takeRetainedValue()
-        
         // From Apple Docs:  Returns the identified type's preferred tag with the specified tag class as a CFString.
         // This is the primary function to use for going from uniform type identifier to tag.
-        guard let mimetype = UTTypeCopyPreferredTagWithClass(retainedUniformTypeID, kUTTagClassMIMEType) else {
+        guard let mimeType = UTTypeCopyPreferredTagWithClass(uniformTypeID.takeRetainedValue(), kUTTagClassMIMEType) else {
             throw error
         }
         
-        let retainedMimeType = mimetype.takeRetainedValue()
-        return retainedMimeType as String
+        return mimeType.takeRetainedValue() as String
     }
 }

--- a/VimeoUpload/Extensions/URL+MIMEType.swift
+++ b/VimeoUpload/Extensions/URL+MIMEType.swift
@@ -7,13 +7,13 @@
 
 import MobileCoreServices
 
-extension URL
+public extension URL
 {
     /// A helper for determining a file's MIMEType
     ///
     /// - Returns: MIMEType as String
     /// - Throws: throws an error if the MIMEType cannot be determined
-    func MIMEType() throws -> String {
+    public func MIMEType() throws -> String {
         
         let userInfo = [NSLocalizedDescriptionKey: "No detectable MIMEType"]
         let error = NSError(domain: "URLExtension.VimeoUpload", code: 0, userInfo: userInfo)

--- a/VimeoUpload/Extensions/URL+MIMEType.swift
+++ b/VimeoUpload/Extensions/URL+MIMEType.swift
@@ -1,0 +1,44 @@
+//
+//  URL+MIMEType.swift
+//  VimeoUpload
+//
+//  Created by Lehrer, Nicole on 2/4/19.
+//
+
+import MobileCoreServices
+
+extension URL
+{
+    /// A helper for determining a file's MIMEType, adapted from:
+    /// - https://stackoverflow.com/questions/31243371/path-extension-and-mime-type-of-file-in-swift
+    /// - https://stackoverflow.com/questions/1363813/how-can-you-read-a-files-mime-type-in-objective-c
+    ///
+    /// - Returns: MIMEType as String
+    /// - Throws: throws an error if the MIMEType cannot be determined
+    func MIMEType() throws -> String {
+        
+        let userInfo = [NSLocalizedDescriptionKey: "No detectable MIMEType"]
+        let error = NSError(domain: "URLExtension.VimeoUpload", code: 0, userInfo: userInfo)
+        
+        guard self.pathExtension.isEmpty == false else {
+            throw error
+        }
+
+        // From Apple Docs: Creates a uniform type identifier for the type indicated by the specified tag.
+        // This is the primary function to use for going from tag (extension/MIMEType/OSType) to uniform type identifier.
+        guard let uniformTypeID = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, self.pathExtension as NSString, nil) else {
+            throw error
+        }
+        
+        let retainedUniformTypeID = uniformTypeID.takeRetainedValue()
+        
+        // From Apple Docs:  Returns the identified type's preferred tag with the specified tag class as a CFString.
+        // This is the primary function to use for going from uniform type identifier to tag.
+        guard let mimetype = UTTypeCopyPreferredTagWithClass(retainedUniformTypeID, kUTTagClassMIMEType) else {
+            throw error
+        }
+        
+        let retainedMimeType = mimetype.takeRetainedValue()
+        return retainedMimeType as String
+    }
+}

--- a/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
+++ b/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
@@ -37,7 +37,7 @@ extension VimeoRequestSerializer
     func createVideoRequest(with url: URL, videoSettings: VideoSettings?, uploadParameters: UploadParameters) throws -> NSMutableURLRequest
     {
         // Create a dictionary containing the file size and MIMEType parameters
-        let baseUploadParameters = self.createFileParameters(url: url)
+        let baseUploadParameters = try self.createFileParameters(url: url)
         
         // Merge in the new key-value pairs passed in, favoring new values for any duplicate keys
         let allUploadParameters = baseUploadParameters.merging(uploadParameters) { (current, new) in new }

--- a/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
+++ b/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoRequestSerializer+Upload.swift
@@ -36,8 +36,8 @@ extension VimeoRequestSerializer
 
     func createVideoRequest(with url: URL, videoSettings: VideoSettings?, uploadParameters: UploadParameters) throws -> NSMutableURLRequest
     {
-        // Create a dictionary containing the file size parameters
-        let baseUploadParameters = try self.createFileSizeParameters(url: url)
+        // Create a dictionary containing the file size and MIMEType parameters
+        let baseUploadParameters = self.createFileParameters(url: url)
         
         // Merge in the new key-value pairs passed in, favoring new values for any duplicate keys
         let allUploadParameters = baseUploadParameters.merging(uploadParameters) { (current, new) in new }

--- a/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
+++ b/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
@@ -100,12 +100,13 @@ extension VimeoRequestSerializer
         let type: String
         do
         {
-            type = try url.MIMEType()
+            type = try url.mimeType()
         }
         catch let error as NSError
         {
             throw error.error(byAddingDomain: UploadErrorDomain.Create.rawValue)
         }
+        
         return [Constants.MIMETypeKey: type]
     }
 
@@ -132,8 +133,7 @@ extension VimeoRequestSerializer
         }
         
         // Merge in the new key-value pairs passed in, favoring new values for any duplicate keys
-        let allFileParameters = fileSizeParameters.merging(fileMIMETypeParameters) { (current, new) in new }
-        return allFileParameters
+        return fileSizeParameters.merging(fileMIMETypeParameters) { (current, new) in new }
     }
     
     func uploadVideoRequest(with source: URL, destination: String) throws -> NSMutableURLRequest

--- a/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
+++ b/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
@@ -35,6 +35,7 @@ extension VimeoRequestSerializer
         static let CreateVideoURI = "/me/videos"
         static let TypeKey = "type"
         static let SizeKey = "size"
+        static let MIMETypeKey = "mime_type"
     }
     
     func myVideosRequest() throws -> NSMutableURLRequest
@@ -93,7 +94,50 @@ extension VimeoRequestSerializer
         
         return [Constants.SizeKey: fileSizeString]
     }
+    
+    private func createMIMETypeParameters(url: URL) throws -> [String: Any]
+    {
+        let type: String
+        do
+        {
+            type = try url.MIMEType()
+        }
+        catch let error as NSError
+        {
+            throw error.error(byAddingDomain: UploadErrorDomain.Create.rawValue)
+        }
+        return [Constants.MIMETypeKey: type]
+    }
 
+    func createFileParameters(url: URL) -> [String: Any]
+    {
+        let fileSizeParameters: [String: Any]
+        do
+        {
+            fileSizeParameters = try self.createFileSizeParameters(url: url)
+        }
+        catch let error
+        {
+            assertionFailure("\(error.localizedDescription)")
+            fileSizeParameters = [:]
+        }
+        
+        let fileMIMETypeParameters: [String: Any]
+        do
+        {
+            fileMIMETypeParameters = try self.createMIMETypeParameters(url: url)
+        }
+        catch let error
+        {
+            assertionFailure("\(error.localizedDescription)")
+            fileMIMETypeParameters = [:]
+        }
+        
+        // Merge in the new key-value pairs passed in, favoring new values for any duplicate keys
+        let allFileParameters = fileSizeParameters.merging(fileMIMETypeParameters) { (current, new) in new }
+        return allFileParameters
+    }
+    
     func uploadVideoRequest(with source: URL, destination: String) throws -> NSMutableURLRequest
     {
         guard FileManager.default.fileExists(atPath: source.path) else

--- a/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
+++ b/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
@@ -109,17 +109,16 @@ extension VimeoRequestSerializer
         return [Constants.MIMETypeKey: type]
     }
 
-    func createFileParameters(url: URL) -> [String: Any]
+    func createFileParameters(url: URL) throws -> [String: Any]
     {
         let fileSizeParameters: [String: Any]
         do
         {
             fileSizeParameters = try self.createFileSizeParameters(url: url)
         }
-        catch let error
+        catch let error as NSError
         {
-            assertionFailure("\(error.localizedDescription)")
-            fileSizeParameters = [:]
+            throw error.error(byAddingDomain: UploadErrorDomain.Create.rawValue)
         }
         
         let fileMIMETypeParameters: [String: Any]
@@ -127,10 +126,9 @@ extension VimeoRequestSerializer
         {
             fileMIMETypeParameters = try self.createMIMETypeParameters(url: url)
         }
-        catch let error
+        catch let error as NSError
         {
-            assertionFailure("\(error.localizedDescription)")
-            fileMIMETypeParameters = [:]
+            throw error.error(byAddingDomain: UploadErrorDomain.Create.rawValue)
         }
         
         // Merge in the new key-value pairs passed in, favoring new values for any duplicate keys


### PR DESCRIPTION
#### Ticket

[VIM-6830](https://vimean.atlassian.net/browse/VIM-6830)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Adds MIMEType information to create video request

#### Implementation Summary

- Adds extension on URL to provide MIMEType
- Parameter dictionary generated in new private method
- This dictionary is bundled with file size into new dictionary provided by `createFileParameters`

#### Reviewer Tips

- This extension was adapted from  
   - https://stackoverflow.com/questions/31243371/path-extension-and-mime-type-of-file-in-swift
   - https://stackoverflow.com/questions/1363813/how-can-you-read-a-files-mime-type-in-objective-c
- Within the extension: We have ownership of the unmanaged object based on the Create Rule [described here](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-CJBEJBHHThe) 
- By using `takeRetainedValue` we are opting into ARC, so we should not have to call release on this object

#### How to Test

- Ensure unit tests pass
