### PR TITLE
Updates use of AFNetworking based on VimeoNetworking changes

### DIFF
--- a/Examples/VimeoUpload+Demos/ViewControllers/BaseCameraRollViewController.swift
+++ b/Examples/VimeoUpload+Demos/ViewControllers/BaseCameraRollViewController.swift
@@ -28,7 +28,6 @@ import UIKit
 import AVFoundation
 import Photos
 import VimeoNetworking
-import AFNetworking
 import VimeoUpload
 
 class BaseCameraRollViewController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout

--- a/Examples/VimeoUpload-iOS-OldUpload/VimeoUpload-iOS-OldUpload.xcodeproj/project.pbxproj
+++ b/Examples/VimeoUpload-iOS-OldUpload/VimeoUpload-iOS-OldUpload.xcodeproj/project.pbxproj
@@ -353,12 +353,10 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/../../Pods/Target Support Files/Pods-VimeoUpload-iOS-OldUpload/Pods-VimeoUpload-iOS-OldUpload-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
 				"${BUILT_PRODUCTS_DIR}/VimeoNetworking/VimeoNetworking.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/VimeoNetworking.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/VimeoUpload-iOS-OldUpload/VimeoUpload-iOS-OldUpload/AppDelegate.swift
+++ b/Examples/VimeoUpload-iOS-OldUpload/VimeoUpload-iOS-OldUpload/AppDelegate.swift
@@ -26,7 +26,6 @@
 
 import UIKit
 import Photos
-import AFNetworking
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate

--- a/Examples/VimeoUpload-iOS-OldUpload/VimeoUpload-iOS-OldUpload/Bridge.h
+++ b/Examples/VimeoUpload-iOS-OldUpload/VimeoUpload-iOS-OldUpload/Bridge.h
@@ -24,5 +24,4 @@
 //  THE SOFTWARE.
 //
 
-@import AFNetworking;
 @import VimeoNetworking;

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS.xcodeproj/project.pbxproj
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS.xcodeproj/project.pbxproj
@@ -404,12 +404,10 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/../../Pods/Target Support Files/Pods-VimeoUpload-iOS/Pods-VimeoUpload-iOS-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
 				"${BUILT_PRODUCTS_DIR}/VimeoNetworking/VimeoNetworking.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/VimeoNetworking.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/AppDelegate.swift
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/AppDelegate.swift
@@ -25,7 +25,6 @@
 //
 
 import UIKit
-import AFNetworking
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate

--- a/Examples/VimeoUpload-iOS/VimeoUpload-iOS/Bridge.h
+++ b/Examples/VimeoUpload-iOS/VimeoUpload-iOS/Bridge.h
@@ -24,5 +24,4 @@
 //  THE SOFTWARE.
 //
 
-@import AFNetworking;
 @import VimeoNetworking;

--- a/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
+++ b/Framework/VimeoUpload/VimeoUpload.xcodeproj/project.pbxproj
@@ -576,14 +576,12 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/../../Pods/Target Support Files/Pods-VimeoUploadTests/Pods-VimeoUploadTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
 				"${BUILT_PRODUCTS_DIR}/VimeoNetworking/VimeoNetworking.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/VimeoNetworking.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 platform :ios, '10.3'
 
 def shared_pods
-    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/VimeoNetworking.git', :branch => 'develop'
+    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/VimeoNetworking.git', :branch => 'tech/VIM-XXXX_MovesAFNetworkingFilesToRepo'
 end
 
 target 'VimeoUpload' do

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 platform :ios, '10.3'
 
 def shared_pods
-    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/VimeoNetworking.git', :branch => 'tech/VIM-XXXX_MovesAFNetworkingFilesToRepo'
+    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/VimeoNetworking.git', :branch => 'develop'
 end
 
 target 'VimeoUpload' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,43 +1,22 @@
 PODS:
-  - AFNetworking (3.1.0):
-    - AFNetworking/NSURLSession (= 3.1.0)
-    - AFNetworking/Reachability (= 3.1.0)
-    - AFNetworking/Security (= 3.1.0)
-    - AFNetworking/Serialization (= 3.1.0)
-    - AFNetworking/UIKit (= 3.1.0)
-  - AFNetworking/NSURLSession (3.1.0):
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-  - AFNetworking/Reachability (3.1.0)
-  - AFNetworking/Security (3.1.0)
-  - AFNetworking/Serialization (3.1.0)
-  - AFNetworking/UIKit (3.1.0):
-    - AFNetworking/NSURLSession
-  - VimeoNetworking (4.0.0):
-    - AFNetworking (= 3.1.0)
+  - VimeoNetworking (5.0.0)
 
 DEPENDENCIES:
-  - VimeoNetworking (from `https://github.com/vimeo/VimeoNetworking.git`, branch `develop`)
-
-SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
-    - AFNetworking
+  - VimeoNetworking (from `https://github.com/vimeo/VimeoNetworking.git`, branch `tech/VIM-XXXX_MovesAFNetworkingFilesToRepo`)
 
 EXTERNAL SOURCES:
   VimeoNetworking:
-    :branch: develop
+    :branch: tech/VIM-XXXX_MovesAFNetworkingFilesToRepo
     :git: https://github.com/vimeo/VimeoNetworking.git
 
 CHECKOUT OPTIONS:
   VimeoNetworking:
-    :commit: 337c6f9806b0b6fb60d19c2b2457835cec02d7b5
+    :commit: 62024727135c9ae1a5324b2b041501df63812c11
     :git: https://github.com/vimeo/VimeoNetworking.git
 
 SPEC CHECKSUMS:
-  AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
-  VimeoNetworking: ba4e86146921ad3b0539516e000db2656abae193
+  VimeoNetworking: 2cfd95cd0da3e3bb4faa12e6a5f04a2860ade5ab
 
-PODFILE CHECKSUM: 766ad1a4bbad744e575a1544e976bcbc4d8ba30d
+PODFILE CHECKSUM: d3407a0da025e297d792c056fca95542e8e8cfdd
 
 COCOAPODS: 1.5.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,21 +2,21 @@ PODS:
   - VimeoNetworking (5.0.0)
 
 DEPENDENCIES:
-  - VimeoNetworking (from `https://github.com/vimeo/VimeoNetworking.git`, branch `tech/VIM-XXXX_MovesAFNetworkingFilesToRepo`)
+  - VimeoNetworking (from `https://github.com/vimeo/VimeoNetworking.git`, branch `develop`)
 
 EXTERNAL SOURCES:
   VimeoNetworking:
-    :branch: tech/VIM-XXXX_MovesAFNetworkingFilesToRepo
+    :branch: develop
     :git: https://github.com/vimeo/VimeoNetworking.git
 
 CHECKOUT OPTIONS:
   VimeoNetworking:
-    :commit: 62024727135c9ae1a5324b2b041501df63812c11
+    :commit: 9d2cb2daee60270b0095c763c63b3db3cba140c9
     :git: https://github.com/vimeo/VimeoNetworking.git
 
 SPEC CHECKSUMS:
   VimeoNetworking: 2cfd95cd0da3e3bb4faa12e6a5f04a2860ade5ab
 
-PODFILE CHECKSUM: d3407a0da025e297d792c056fca95542e8e8cfdd
+PODFILE CHECKSUM: 766ad1a4bbad744e575a1544e976bcbc4d8ba30d
 
 COCOAPODS: 1.5.2

--- a/VimeoUpload/Descriptor System/ConnectivityManager.swift
+++ b/VimeoUpload/Descriptor System/ConnectivityManager.swift
@@ -25,7 +25,7 @@
 //
 
 import Foundation
-import AFNetworking
+import VimeoNetworking
 
 protocol ConnectivityManagerDelegate: class
 {

--- a/VimeoUpload/Descriptor System/Descriptor.swift
+++ b/VimeoUpload/Descriptor System/Descriptor.swift
@@ -25,7 +25,7 @@
 //
 
 import Foundation
-import AFNetworking
+import VimeoNetworking
 
 public enum DescriptorState: String
 {

--- a/VimeoUpload/Descriptor System/DescriptorManager.swift
+++ b/VimeoUpload/Descriptor System/DescriptorManager.swift
@@ -25,7 +25,7 @@
 //
 
 import Foundation
-import AFNetworking
+import VimeoNetworking
 
 public enum DescriptorManagerNotification: String
 {

--- a/VimeoUpload/Extensions/AFURLSessionManager+Extensions.swift
+++ b/VimeoUpload/Extensions/AFURLSessionManager+Extensions.swift
@@ -25,7 +25,7 @@
 //
 
 import Foundation
-import AFNetworking
+import VimeoNetworking
 
 extension AFURLSessionManager
 {

--- a/VimeoUpload/Upload/Controllers/VideoDeletionManager.swift
+++ b/VimeoUpload/Upload/Controllers/VideoDeletionManager.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 import VimeoNetworking
 
 @objc public class VideoDeletionManager: NSObject

--- a/VimeoUpload/Upload/Controllers/VideoRefreshManager.swift
+++ b/VimeoUpload/Upload/Controllers/VideoRefreshManager.swift
@@ -26,7 +26,6 @@
 
 import Foundation
 import VimeoNetworking
-import AFNetworking
 
 @objc public protocol VideoRefreshManagerDelegate
 {

--- a/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import AFNetworking
 import VimeoNetworking
 
 @objc public class CAMUploadDescriptor: ProgressDescriptor, VideoDescriptor

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -26,7 +26,6 @@
 
 import Foundation
 import VimeoNetworking
-import AFNetworking
 
 @objc open class UploadDescriptor: ProgressDescriptor, VideoDescriptor
 {

--- a/VimeoUpload/Upload/Descriptor System/Old Upload/OldUploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/Old Upload/OldUploadDescriptor.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import AFNetworking
 import VimeoNetworking
 
 @objc public class OldUploadDescriptor: ProgressDescriptor, VideoDescriptor

--- a/VimeoUpload/Upload/Extensions/AFURLSessionManager+Upload.swift
+++ b/VimeoUpload/Upload/Extensions/AFURLSessionManager+Upload.swift
@@ -25,7 +25,7 @@
 //
 
 import Foundation
-import AFNetworking
+import VimeoNetworking
 
 @objc public extension AFURLSessionManager
 {


### PR DESCRIPTION
#### Ticket

N/A

#### Issue Summary

We decided to fold all AFNetworking files into our own repo instead of managing them as an external dependency. This will allow us better control of file visibility and also what should/shouldn't be included.

The motivator for this change was an issue Magisto has started to encounter when consuming our library, where Apple is giving warnings for deprecated use of `UIWebView` which will soon end up in rejected submissions.

There is a PR on AFNetworking [here](https://github.com/AFNetworking/AFNetworking/issues/4428) that has been opened since late August and still waiting to be merged, which indicates the support for the library is slowing down substantially and we don't expect any major updates will be available that we may be able to take advantage of.

#### Implementation Summary

* Remove all AFNetworking imports, 
* Add VimeoNetworking imports where needed

#### How to Test

- Ensure you can build and all tests pass

See this [PR](https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/3137) on the main repo that is consuming these changes.

This is the VimeoNetworking [PR](https://github.com/vimeo/VimeoNetworking/pull/363).
