### PR TITLE
VIM-XXXX: Refactors VimeoRequestSerializer API usage

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 platform :ios, '10.3'
 
 def shared_pods
-    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/vimeonetworking.git', :branch => 'feature/VIM-XXXX_AFNetworkingDeprecation'
+    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/vimeonetworking.git', :branch => 'VIM-XXXX_RequestSerializerRefactor'
 end
 
 target 'VimeoUpload' do

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 platform :ios, '10.3'
 
 def shared_pods
-    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/vimeonetworking.git', :branch => 'VIM-XXXX_RequestSerializerRefactor'
+    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/vimeonetworking.git', :branch => 'feature/VIM-XXXX_AFNetworkingDeprecation'
 end
 
 target 'VimeoUpload' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,21 +2,21 @@ PODS:
   - VimeoNetworking (5.0.0)
 
 DEPENDENCIES:
-  - VimeoNetworking (from `https://github.com/vimeo/vimeonetworking.git`, branch `VIM-XXXX_RequestSerializerRefactor`)
+  - VimeoNetworking (from `https://github.com/vimeo/vimeonetworking.git`, branch `feature/VIM-XXXX_AFNetworkingDeprecation`)
 
 EXTERNAL SOURCES:
   VimeoNetworking:
-    :branch: VIM-XXXX_RequestSerializerRefactor
+    :branch: feature/VIM-XXXX_AFNetworkingDeprecation
     :git: https://github.com/vimeo/vimeonetworking.git
 
 CHECKOUT OPTIONS:
   VimeoNetworking:
-    :commit: be2ad19c02c00b0d0c7d9a205a6820a60e28f064
+    :commit: 529ea8359d73e02183df94d74453a69a079e9fbb
     :git: https://github.com/vimeo/vimeonetworking.git
 
 SPEC CHECKSUMS:
   VimeoNetworking: 2cfd95cd0da3e3bb4faa12e6a5f04a2860ade5ab
 
-PODFILE CHECKSUM: f061a740dc26cf4c03f8022c46bb27d49ab36d66
+PODFILE CHECKSUM: 8ffb8802a657a8ec73d590dd9002347ef11b2339
 
 COCOAPODS: 1.5.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,21 +2,21 @@ PODS:
   - VimeoNetworking (5.0.0)
 
 DEPENDENCIES:
-  - VimeoNetworking (from `https://github.com/vimeo/vimeonetworking.git`, branch `feature/VIM-XXXX_AFNetworkingDeprecation`)
+  - VimeoNetworking (from `https://github.com/vimeo/vimeonetworking.git`, branch `VIM-XXXX_RequestSerializerRefactor`)
 
 EXTERNAL SOURCES:
   VimeoNetworking:
-    :branch: feature/VIM-XXXX_AFNetworkingDeprecation
+    :branch: VIM-XXXX_RequestSerializerRefactor
     :git: https://github.com/vimeo/vimeonetworking.git
 
 CHECKOUT OPTIONS:
   VimeoNetworking:
-    :commit: 4f09956144ca6d08b22964efb1783df1dbb7be00
+    :commit: be2ad19c02c00b0d0c7d9a205a6820a60e28f064
     :git: https://github.com/vimeo/vimeonetworking.git
 
 SPEC CHECKSUMS:
   VimeoNetworking: 2cfd95cd0da3e3bb4faa12e6a5f04a2860ade5ab
 
-PODFILE CHECKSUM: 8ffb8802a657a8ec73d590dd9002347ef11b2339
+PODFILE CHECKSUM: f061a740dc26cf4c03f8022c46bb27d49ab36d66
 
 COCOAPODS: 1.5.2

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoRequestSerializer+Thumbnail.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoRequestSerializer+Thumbnail.swift
@@ -17,7 +17,7 @@ extension VimeoRequestSerializer
         let url = URL(string: "\(uri)/pictures", relativeTo: VimeoBaseURL)!
         
         var error: NSError?
-        let request = self.request(withMethod: "POST", urlString: url.absoluteString, parameters: nil, error: &error)
+        let request = self.request(withMethod: .post, urlString: url.absoluteString, parameters: nil, error: &error)
         
         if let error = error
         {
@@ -33,7 +33,7 @@ extension VimeoRequestSerializer
         
         var error: NSError?
         let activationParams = ["active" : "true"]
-        let request = self.request(withMethod: "PATCH", urlString: url.absoluteString, parameters: activationParams, error: &error)
+        let request = self.request(withMethod: .patch, urlString: url.absoluteString, parameters: activationParams, error: &error)
         
         if let error = error
         {
@@ -50,7 +50,7 @@ extension VimeoRequestSerializer
         }
         
         var error: NSError?
-        let request = self.request(withMethod: "PUT", urlString: destination, parameters: nil, error: &error)
+        let request = self.request(withMethod: .put, urlString: destination, parameters: nil, error: &error)
         if let error = error {
             throw error.error(byAddingDomain: UploadErrorDomain.UploadThumbnail.rawValue)
         }

--- a/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
+++ b/VimeoUpload/Upload/Networking/Shared/VimeoRequestSerializer+SharedUpload.swift
@@ -43,7 +43,7 @@ extension VimeoRequestSerializer
         let url = URL(string: "/me/videos", relativeTo: VimeoBaseURL)!
         var error: NSError?
         
-        let request = self.request(withMethod: "GET", urlString: url.absoluteString, parameters: nil, error: &error)
+        let request = self.request(withMethod: .get, urlString: url.absoluteString, parameters: nil, error: &error)
         if let error = error
         {
             throw error.error(byAddingDomain: UploadErrorDomain.MyVideos.rawValue)
@@ -66,7 +66,7 @@ extension VimeoRequestSerializer
     func createVideoRequest(with url: URL, parameters: [String: Any]) throws -> NSMutableURLRequest
     {
         var error: NSError?
-        let request = self.request(withMethod: "POST", urlString: url.absoluteString, parameters: parameters, error: &error)
+        let request = self.request(withMethod: .post, urlString: url.absoluteString, parameters: parameters, error: &error)
 
         if let error = error
         {
@@ -144,7 +144,7 @@ extension VimeoRequestSerializer
         }
         
         var error: NSError?
-        let request = self.request(withMethod: "PUT", urlString: destination, parameters: nil, error: &error)
+        let request = self.request(withMethod: .put, urlString: destination, parameters: nil, error: &error)
         if let error = error
         {
             throw error.error(byAddingDomain: UploadErrorDomain.Upload.rawValue)
@@ -176,7 +176,7 @@ extension VimeoRequestSerializer
         let url = URL(string: uri, relativeTo: VimeoBaseURL)!
         var error: NSError?
         
-        let request = self.request(withMethod: "DELETE", urlString: url.absoluteString, parameters: nil, error: &error)
+        let request = self.request(withMethod: .delete, urlString: url.absoluteString, parameters: nil, error: &error)
         if let error = error
         {
             throw error.error(byAddingDomain: UploadErrorDomain.Activate.rawValue)
@@ -201,7 +201,7 @@ extension VimeoRequestSerializer
             throw NSError(domain: UploadErrorDomain.VideoSettings.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "Parameters dictionary is empty."])
         }
         
-        let request = self.request(withMethod: "PATCH", urlString: url.absoluteString, parameters: parameters, error: &error)
+        let request = self.request(withMethod: .patch, urlString: url.absoluteString, parameters: parameters, error: &error)
         if let error = error
         {
             throw error.error(byAddingDomain: UploadErrorDomain.VideoSettings.rawValue)
@@ -220,7 +220,7 @@ extension VimeoRequestSerializer
         let url = URL(string: videoUri, relativeTo: VimeoBaseURL)!
         var error: NSError?
         
-        let request = self.request(withMethod: "DELETE", urlString: url.absoluteString, parameters: nil, error: &error)
+        let request = self.request(withMethod: .delete, urlString: url.absoluteString, parameters: nil, error: &error)
         if let error = error
         {
             throw error.error(byAddingDomain: UploadErrorDomain.Delete.rawValue)
@@ -239,7 +239,7 @@ extension VimeoRequestSerializer
         let url = URL(string: videoUri, relativeTo: VimeoBaseURL)!
         var error: NSError?
         
-        let request = self.request(withMethod: "GET", urlString: url.absoluteString, parameters: nil, error: &error)
+        let request = self.request(withMethod: .get, urlString: url.absoluteString, parameters: nil, error: &error)
         if let error = error
         {
             throw error.error(byAddingDomain: UploadErrorDomain.Video.rawValue)


### PR DESCRIPTION
#### Ticket

[VIM-XXXX](https://vimean.atlassian.net/browse/VIM-XXXX)

#### Pull Request Checklist

- [X] Resolved any merge conflicts
- [X] No build errors or warnings are introduced
- [X] New files are written in Swift
- [X] New classes contain license headers
- [X] New classes have Documentation
- [X] New public methods have Documentation

#### Issue Summary

This is a simple refactor to accommodate changes on VimeoNetworking via [this PR](https://github.com/vimeo/VimeoNetworking/pull/368)
 
#### Implementation Summary

- Mostly replaces Stringy typed methods with the corresponding `enum` case.

#### How to Test

- Build and run, ensure unit tests pass