### PR TITLE
Adjust code for updated Vimeo request/responce serializers.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 platform :ios, '10.3'
 
 def shared_pods
-    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/vimeonetworking.git', :branch => 'feature/VIM-XXXX_AFNetworkingDeprecation'
+    pod 'VimeoNetworking', :git => 'https://github.com/vimeo/vimeonetworking.git', :branch => 'fix/re-structure-netwoking-base-classes'
 end
 
 target 'VimeoUpload' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,21 +2,21 @@ PODS:
   - VimeoNetworking (5.0.0)
 
 DEPENDENCIES:
-  - VimeoNetworking (from `https://github.com/vimeo/vimeonetworking.git`, branch `feature/VIM-XXXX_AFNetworkingDeprecation`)
+  - VimeoNetworking (from `https://github.com/vimeo/vimeonetworking.git`, branch `fix/re-structure-netwoking-base-classes`)
 
 EXTERNAL SOURCES:
   VimeoNetworking:
-    :branch: feature/VIM-XXXX_AFNetworkingDeprecation
+    :branch: fix/re-structure-netwoking-base-classes
     :git: https://github.com/vimeo/vimeonetworking.git
 
 CHECKOUT OPTIONS:
   VimeoNetworking:
-    :commit: 529ea8359d73e02183df94d74453a69a079e9fbb
+    :commit: 50e8a565dc8c714da393b47d7ba7f0f857ae7481
     :git: https://github.com/vimeo/vimeonetworking.git
 
 SPEC CHECKSUMS:
-  VimeoNetworking: 2cfd95cd0da3e3bb4faa12e6a5f04a2860ade5ab
+  VimeoNetworking: 058307291362977d736c46f6cf10b43cd7b2a4ce
 
-PODFILE CHECKSUM: 8ffb8802a657a8ec73d590dd9002347ef11b2339
+PODFILE CHECKSUM: 88e87152a64b6a3a0f1126c9f5adec6ee7ee6aee
 
-COCOAPODS: 1.5.2
+COCOAPODS: 1.8.4

--- a/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/CAMUploadDescriptor.swift
@@ -128,7 +128,7 @@ import VimeoNetworking
     
     @objc override public func taskDidFinishDownloading(sessionManager: VimeoSessionManager, task: URLSessionDownloadTask, url: URL) -> URL?
     {
-        let responseSerializer = sessionManager.jsonResponseSerializer
+        let responseSerializer = sessionManager.vimeoResponseSerializer
         
         do
         {

--- a/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
+++ b/VimeoUpload/Upload/Descriptor System/Cameo/VimeoSessionManager+ThumbnailUpload.swift
@@ -13,20 +13,20 @@ extension VimeoSessionManager
 {
     func createThumbnailDownloadTask(uri: VideoUri) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.createThumbnailRequest(with: uri) as URLRequest
+        let request = try self.vimeoRequestSerializer.createThumbnailRequest(with: uri) as URLRequest
         return self.download(request, then: { _ in })
     }
     
     func uploadThumbnailTask(source: URL, destination: String, completionHandler: ErrorBlock?) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.uploadThumbnailRequest(with: source, destination: destination) as URLRequest
-        return self.upload(request, sourceFile: source) { [jsonResponseSerializer] sessionManagingResult in
+        let request = try self.vimeoRequestSerializer.uploadThumbnailRequest(with: source, destination: destination) as URLRequest
+        return self.upload(request, sourceFile: source) { [vimeoResponseSerializer] sessionManagingResult in
             switch sessionManagingResult.result {
             case .failure(let error as NSError):
                 completionHandler?(error)
             case .success(let json):
                 do {
-                    try jsonResponseSerializer.process(
+                    try vimeoResponseSerializer.process(
                         uploadThumbnailResponse: sessionManagingResult.response,
                         responseObject: json as AnyObject,
                         error: nil
@@ -41,7 +41,7 @@ extension VimeoSessionManager
     
     func activateThumbnailTask(activationUri: String) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.activateThumbnailRequest(with: activationUri) as URLRequest
+        let request = try self.vimeoRequestSerializer.activateThumbnailRequest(with: activationUri) as URLRequest
         return self.download(request) { _ in }
     }
 }

--- a/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/New Upload (Private)/UploadDescriptor.swift
@@ -92,7 +92,7 @@ import VimeoNetworking
             
             let uploadLink = try self.uploadStrategy.uploadLink(from: video)
             
-            let uploadRequest = try self.uploadStrategy.uploadRequest(requestSerializer: sessionManager.jsonRequestSerializer, fileUrl: self.url, uploadLink: uploadLink)
+            let uploadRequest = try self.uploadStrategy.uploadRequest(requestSerializer: sessionManager.vimeoRequestSerializer, fileUrl: self.url, uploadLink: uploadLink)
             let task = sessionManager.uploadVideoTask(source: self.url, request: uploadRequest, completionHandler: nil)
             
             self.currentTaskIdentifier = task?.id

--- a/VimeoUpload/Upload/Descriptor System/Old Upload/OldUploadDescriptor.swift
+++ b/VimeoUpload/Upload/Descriptor System/Old Upload/OldUploadDescriptor.swift
@@ -141,7 +141,7 @@ import VimeoNetworking
     
     @objc override public func taskDidFinishDownloading(sessionManager: VimeoSessionManager, task: URLSessionDownloadTask, url: URL) -> URL?
     {
-        let responseSerializer = sessionManager.jsonResponseSerializer
+        let responseSerializer = sessionManager.vimeoResponseSerializer
         
         do
         {

--- a/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoSessionManager+Upload.swift
+++ b/VimeoUpload/Upload/Networking/New Upload (Private)/VimeoSessionManager+Upload.swift
@@ -40,9 +40,9 @@ extension VimeoSessionManager
     
     func createVideoDataTask(url: URL, videoSettings: VideoSettings?, uploadParameters: UploadParameters, completionHandler: @escaping VideoCompletionHandler) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.createVideoRequest(with: url, videoSettings: videoSettings, uploadParameters: uploadParameters) as URLRequest
+        let request = try self.vimeoRequestSerializer.createVideoRequest(with: url, videoSettings: videoSettings, uploadParameters: uploadParameters) as URLRequest
 
-        return self.request(request) { [jsonResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
+        return self.request(request) { [vimeoResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
             // Do model parsing on a background thread
             DispatchQueue.global(qos: .default).async(execute: {
                 switch sessionManagingResult.result {
@@ -50,7 +50,7 @@ extension VimeoSessionManager
                     completionHandler(nil, error as NSError)
                 case .success(let json):
                     do {                        
-                        let video = try jsonResponseSerializer.process(
+                        let video = try vimeoResponseSerializer.process(
                             videoResponse: sessionManagingResult.response,
                             responseObject: json as AnyObject,
                             error: nil
@@ -67,20 +67,20 @@ extension VimeoSessionManager
     
     func createVideoDownloadTask(url: URL, videoSettings: VideoSettings?, uploadParameters: UploadParameters) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.createVideoRequest(with: url, videoSettings: videoSettings, uploadParameters: uploadParameters) as URLRequest        
+        let request = try self.vimeoRequestSerializer.createVideoRequest(with: url, videoSettings: videoSettings, uploadParameters: uploadParameters) as URLRequest
         let task = self.download(request) { _ in }
         return task
     }
     
     func uploadVideoTask(source: URL, request: URLRequest, completionHandler: ErrorBlock?) -> Task?
     {
-        return self.upload(request, sourceFile: source) { [jsonResponseSerializer] sessionManagingResult in
+        return self.upload(request, sourceFile: source) { [vimeoResponseSerializer] sessionManagingResult in
             switch sessionManagingResult.result {
             case .failure(let error):
                 completionHandler?(error as NSError)
             case .success(let json):
                 do {
-                    try jsonResponseSerializer.process(
+                    try vimeoResponseSerializer.process(
                         uploadVideoResponse: sessionManagingResult.response,
                         responseObject: json as AnyObject,
                         error: nil

--- a/VimeoUpload/Upload/Networking/Old Upload/VimeoSessionManager+OldUpload.swift
+++ b/VimeoUpload/Upload/Networking/Old Upload/VimeoSessionManager+OldUpload.swift
@@ -32,8 +32,8 @@ extension VimeoSessionManager
 {
     public func myVideosDataTask(completionHandler: @escaping VideosCompletionHandler) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.myVideosRequest() as URLRequest
-        return self.request(request) { [jsonResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
+        let request = try self.vimeoRequestSerializer.myVideosRequest() as URLRequest
+        return self.request(request) { [vimeoResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
             // Do model parsing on a background thread
             DispatchQueue.global(qos: .default).async {
                 switch sessionManagingResult.result {
@@ -41,7 +41,7 @@ extension VimeoSessionManager
                     completionHandler(nil, error)
                 case .success(let json):
                     do {
-                        let videos = try jsonResponseSerializer.process(
+                        let videos = try vimeoResponseSerializer.process(
                             myVideosResponse: sessionManagingResult.response,
                             responseObject: json as AnyObject,
                             error: nil
@@ -57,20 +57,20 @@ extension VimeoSessionManager
 
     public func createVideoDownloadTask(url: URL) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.createVideoRequest(with: url) as URLRequest
+        let request = try self.vimeoRequestSerializer.createVideoRequest(with: url) as URLRequest
         return self.download(request) { _ in }
     }
     
     func uploadVideoTask(source: URL, destination: String, completionHandler: ErrorBlock?) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.uploadVideoRequest(with: source, destination: destination) as URLRequest
-        return self.upload(request, sourceFile: source) { [jsonResponseSerializer] sessionManagingResult in
+        let request = try self.vimeoRequestSerializer.uploadVideoRequest(with: source, destination: destination) as URLRequest
+        return self.upload(request, sourceFile: source) { [vimeoResponseSerializer] sessionManagingResult in
             switch sessionManagingResult.result {
             case .failure(let error):
                 completionHandler?(error as NSError)
             case .success(let json):
                 do {
-                    try jsonResponseSerializer.process(
+                    try vimeoResponseSerializer.process(
                         uploadVideoResponse: sessionManagingResult.response,
                         responseObject: json as AnyObject,
                         error: nil
@@ -86,21 +86,21 @@ extension VimeoSessionManager
     // For use with background sessions, use session delegate methods for destination and completion
     func activateVideoDownloadTask(uri activationUri: String) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.activateVideoRequest(withURI: activationUri) as URLRequest
+        let request = try self.vimeoRequestSerializer.activateVideoRequest(withURI: activationUri) as URLRequest
         return self.download(request) { _ in }
     }
 
     // For use with background sessions, use session delegate methods for destination and completion
     func videoSettingsDownloadTask(videoUri: String, videoSettings: VideoSettings) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.videoSettingsRequest(with: videoUri, videoSettings: videoSettings) as URLRequest
+        let request = try self.vimeoRequestSerializer.videoSettingsRequest(with: videoUri, videoSettings: videoSettings) as URLRequest
         return self.download(request) { _ in }
     }
 
     public func videoSettingsDataTask(videoUri: String, videoSettings: VideoSettings, completionHandler: @escaping VideoCompletionHandler) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.videoSettingsRequest(with: videoUri, videoSettings: videoSettings) as URLRequest
-        return self.request(request) { [jsonResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
+        let request = try self.vimeoRequestSerializer.videoSettingsRequest(with: videoUri, videoSettings: videoSettings) as URLRequest
+        return self.request(request) { [vimeoResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
             // Do model parsing on a background thread
             DispatchQueue.global(qos: .default).async {
                 switch sessionManagingResult.result {
@@ -108,7 +108,7 @@ extension VimeoSessionManager
                     completionHandler(nil, error as NSError)
                 case .success(let json):
                     do {
-                        let video = try jsonResponseSerializer.process(
+                        let video = try vimeoResponseSerializer.process(
                             videoSettingsResponse: sessionManagingResult.response,
                             responseObject: json as AnyObject,
                             error: nil
@@ -124,14 +124,14 @@ extension VimeoSessionManager
     
     func deleteVideoDataTask(videoUri: String, completionHandler: @escaping ErrorBlock) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.deleteVideoRequest(with: videoUri) as URLRequest
-        return self.request(request) { [jsonResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
+        let request = try self.vimeoRequestSerializer.deleteVideoRequest(with: videoUri) as URLRequest
+        return self.request(request) { [vimeoResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
             switch sessionManagingResult.result {
             case .failure(let error):
                 completionHandler(error as NSError)
             case .success(let json):
                 do {
-                    try jsonResponseSerializer.process(
+                    try vimeoResponseSerializer.process(
                         deleteVideoResponse: sessionManagingResult.response,
                         responseObject: json as AnyObject,
                         error: nil
@@ -146,14 +146,14 @@ extension VimeoSessionManager
 
     func videoDataTask(videoUri: String, completionHandler: @escaping VideoCompletionHandler) throws -> Task?
     {
-        let request = try self.jsonRequestSerializer.videoRequest(with: videoUri) as URLRequest
-        return self.request(request) { [jsonResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
+        let request = try self.vimeoRequestSerializer.videoRequest(with: videoUri) as URLRequest
+        return self.request(request) { [vimeoResponseSerializer] (sessionManagingResult: SessionManagingResult<JSON>) in
             switch sessionManagingResult.result {
             case .failure(let error as NSError):
                 completionHandler(nil, error)
             case .success(let json):
                 do {
-                    let video = try jsonResponseSerializer.process(
+                    let video = try vimeoResponseSerializer.process(
                         videoResponse: sessionManagingResult.response,
                         responseObject: json as AnyObject,
                         error: nil


### PR DESCRIPTION
#### Ticket

[VIM-7242](https://github.vimeows.com/Vimeo/vimeo-live-mobile-issues/issues/435?email_source=notifications&email_token=AAAAEHJI5G6JDSTWRUZTYD3QQ37L5A5CNFSM4AAB4PBKYY3PNVWWK3TUL52HS4DFVREXG43VMVBW63LNMVXHJKTDN5WW2ZLOORPWSZGOAAB7VSY)

#### Pull Request Checklist

- [ ] Resolved any merge conflicts
- [ ] No build errors or warnings are introduced
- [ ] New files are written in Swift
- [ ] New classes contain license headers
- [ ] New classes have Documentation
- [ ] New public methods have Documentation

#### Issue Summary

- This PR updates code for acquiring VimeoRequestSerializer and VimeoResponseSerializer  properties from VimeoSessionManager.

#### Implementation Summary

- VimeoSessionManager 'jsonRequestSerializer' and 'jsonResponseSerializer' properties replaced with 'vimeoRequestSerializer' and 'vimeoResponseSerializer'.

#### Reviewer Tips

- N/A

#### How to Test

- N/A