### PR TITLE
WRKFL-XXX: Update Archiving/Un-archiving Method Calls

### DIFF
--- a/VimeoUpload/Descriptor System/KeyedArchiver.swift
+++ b/VimeoUpload/Descriptor System/KeyedArchiver.swift
@@ -51,10 +51,7 @@ public class KeyedArchiver: ArchiverProtocol
 
         if #available(iOS 12.0, *) {
             do {
-                guard let url = URL(string: path) else {
-                    return nil
-                }
-
+                let url = URL(fileURLWithPath: path)
                 let data = try Data(contentsOf: url)
                 return try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)
             } catch {
@@ -70,9 +67,8 @@ public class KeyedArchiver: ArchiverProtocol
         let path = self.archivePath(key: self.key(withPrefix: self.prefix, key: key))
 
         if #available(iOS 12.0, *) {
-            guard let url = URL(string: path) else { return }
-
             do {
+                let url = URL(fileURLWithPath: path)
                 let data = try NSKeyedArchiver.archivedData(withRootObject: object, requiringSecureCoding: false)
                 try data.write(to: url)
             } catch let error {

--- a/VimeoUpload/Extensions/ArchiveMigrator.swift
+++ b/VimeoUpload/Extensions/ArchiveMigrator.swift
@@ -50,8 +50,17 @@ class ArchiveMigrator: ArchiveMigrating
     func loadArchiveFile(relativeFileURL: URL) -> Any?
     {
         let fileURL = self.fileURL(withRelativeFilePath: relativeFileURL.path)
-        
-        return NSKeyedUnarchiver.unarchiveObject(withFile: fileURL.path)
+
+        if #available(iOS 12.0, *) {
+            do {
+                let data = try Data(contentsOf: fileURL)
+                return try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)
+            } catch {
+                return nil
+            }
+        } else {
+            return NSKeyedUnarchiver.unarchiveObject(withFile: fileURL.path)
+        }
     }
     
     func deleteArchiveFile(relativeFileURL: URL)


### PR DESCRIPTION
## Ticket

N/A

## Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

## Issue Summary

As we are moving away from both iOS 10 and 11, some methods in the `NSKeyedArchiver` and `NSKeyedUnarchiver` APIs have been marked obsolete, so it is time for us to move away from those methods.

## Implementation Summary

Substituted deprecated archiving/unarchiving methods with the recent ones.

## Reviewer Tips

Vimeo client's PR: https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/3552

## How to Test

Please test the code with the Vimeo client app extensively. Make sure that there's nothing weird happening to uploads.
